### PR TITLE
Add Options Argument in Install Function

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -35,7 +35,7 @@ function(cdeps_install_package)
   if(NOT EXISTS ${BUILD_DIR})
     message(STATUS "CDeps: Configuring ${ARG_NAME}")
     execute_process(
-      COMMAND ${CMAKE_COMMAND} ${SOURCE_DIR} -B ${BUILD_DIR} -D FMT_MASTER_PROJECT=OFF
+      COMMAND ${CMAKE_COMMAND} ${SOURCE_DIR} -B ${BUILD_DIR}
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
     )

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -3,8 +3,9 @@
 #   - NAME: The package name.
 #   - GIT_URL: The Git URL of the package.
 #   - GIT_TAG: The Git tag of the package.
+#   - OPTIONS: The options to be passed during the build configuration of the package.
 function(cdeps_install_package)
-  cmake_parse_arguments(ARG "" "NAME;GIT_URL;GIT_TAG" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "NAME;GIT_URL;GIT_TAG" "OPTIONS" ${ARGN})
 
   # Set the default CDEPS_ROOT directory if not provided.
   if(NOT CDEPS_ROOT)
@@ -34,8 +35,11 @@ function(cdeps_install_package)
   set(BUILD_DIR ${CDEPS_ROOT}/${ARG_NAME}-build)
   if(NOT EXISTS ${BUILD_DIR})
     message(STATUS "CDeps: Configuring ${ARG_NAME}")
+    foreach(OPTION ${ARG_OPTIONS})
+      list(APPEND CONFIGURE_ARGS -D ${OPTION})
+    endforeach()
     execute_process(
-      COMMAND ${CMAKE_COMMAND} ${SOURCE_DIR} -B ${BUILD_DIR}
+      COMMAND ${CMAKE_COMMAND} -B ${BUILD_DIR} ${CONFIGURE_ARGS} ${SOURCE_DIR}
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
     )

--- a/test/project/cmake/FindFMT.cmake
+++ b/test/project/cmake/FindFMT.cmake
@@ -8,6 +8,7 @@ cdeps_install_package(
   NAME FMT
   GIT_URL https://github.com/fmtlib/fmt
   GIT_TAG 10.2.1
+  OPTIONS FMT_MASTER_PROJECT=OFF
 )
 
 find_package(FMT REQUIRED CONFIG)


### PR DESCRIPTION
This pull request resolves #8 by adding an `OPTIONS` argument to `cdeps_install_package`, enabling users to define configurations during package builds. The test project now uses this argument with `FMT_MASTER_PROJECT=OFF`. Also, it removes the accidental `-D FMT_MASTER_PROJECT=OFF` in `cdeps_install_package`.