### PR TITLE
Add Include Guard in Modules

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -1,3 +1,5 @@
+include_guard(GLOBAL)
+
 # Function to download, build, and install missing packages.
 # Arguments:
 #   - NAME: The package name.


### PR DESCRIPTION
This pull request resolves #10 by adding an `include_guard` function on the top of the `CDeps.cmake` module to prevent its functions from being included twice.