### PR TITLE
Disable Install on Subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,18 +10,20 @@ project(
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
-  enable_testing()
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  if(BUILD_TESTING)
+    enable_testing()
 
-  add_test(
-    NAME BuildProjectTest
-    COMMAND cmake
-      -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/BuildProjectTest.cmake
+    add_test(
+      NAME BuildProjectTest
+      COMMAND cmake
+        -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/test/BuildProjectTest.cmake
+    )
+  endif()
+
+  install(
+    FILES cmake/CDeps.cmake
+    DESTINATION lib/cmake
   )
 endif()
-
-install(
-  FILES cmake/CDeps.cmake
-  DESTINATION lib/cmake
-)


### PR DESCRIPTION
This pull request resolves #12 by enabling the installation target only if the project is not included as a subproject. 