### PR TITLE
Add License Notice to Exported Files

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -1,3 +1,6 @@
+# This code is licensed under the terms of the MIT License.
+# Copyright (c) 2024 Alfi Maulana
+
 include_guard(GLOBAL)
 
 # Function to download, build, and install missing packages.


### PR DESCRIPTION
This pull request resolves #20 by adding a license notice on top of the `cmake/CDeps.cmake` file.