### PR TITLE
Separate Argument Parsing Function

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -1,5 +1,9 @@
 include_guard(GLOBAL)
 
+macro(_cdeps_parse_arguments)
+  cmake_parse_arguments(ARG "" "NAME;GIT_URL;GIT_TAG" "OPTIONS" ${ARGN})
+endmacro()
+
 # Function to download, build, and install missing packages.
 # Arguments:
 #   - NAME: The package name.
@@ -7,7 +11,7 @@ include_guard(GLOBAL)
 #   - GIT_TAG: The Git tag of the package.
 #   - OPTIONS: The options to be passed during the build configuration of the package.
 function(cdeps_install_package)
-  cmake_parse_arguments(ARG "" "NAME;GIT_URL;GIT_TAG" "OPTIONS" ${ARGN})
+  _cdeps_parse_arguments(${ARGN})
 
   # Set the default CDEPS_ROOT directory if not provided.
   if(NOT CDEPS_ROOT)

--- a/test/CDepsParseArgsTest.cmake
+++ b/test/CDepsParseArgsTest.cmake
@@ -1,0 +1,53 @@
+# Matches everything if not defined
+if(NOT TEST_MATCHES)
+  set(TEST_MATCHES ".*")
+endif()
+
+set(TEST_COUNT 0)
+
+include(CDeps)
+
+function(expect VAR EXPECTED)
+  if(NOT ${VAR} STREQUAL "${EXPECTED}")
+    message(FATAL_ERROR "${VAR} expected to be equal to ${EXPECTED} but got ${${VAR}} instead")
+  endif()
+endfunction()
+
+function(expect_undefined VAR)
+  if(${VAR})
+    message(FATAL_ERROR "${VAR} should not be defined")
+  endif()
+endfunction()
+
+if("Parse arguments" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  _cdeps_parse_arguments(
+    NAME Foo
+    GIT_URL https://github.com/foo/foo
+    GIT_TAG 1.2.3
+    OPTIONS
+      BUILD_TESTING=OFF
+      BUILD_DOCS=OFF
+  )
+
+  expect(ARG_NAME Foo)
+  expect(ARG_GIT_URL https://github.com/foo/foo)
+  expect(ARG_GIT_TAG 1.2.3)
+  expect(ARG_OPTIONS "BUILD_TESTING=OFF;BUILD_DOCS=OFF")
+endif()
+
+if("Parse empty arguments" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
+  _cdeps_parse_arguments()
+
+  expect_undefined(ARG_NAME)
+  expect_undefined(ARG_GIT_URL)
+  expect_undefined(ARG_GIT_TAG)
+  expect_undefined(ARG_OPTIONS)
+endif()
+
+if(TEST_COUNT LESS_EQUAL 0)
+  message(FATAL_ERROR "Nothing to test with: ${TEST_MATCHES}")
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,12 @@ function(add_cmake_test FILE)
 endfunction()
 
 add_cmake_test(
+  CDepsParseArgsTest.cmake
+  "Parse arguments"
+  "Parse empty arguments"
+)
+
+add_cmake_test(
   CDepsTest.cmake
   "Install missing dependencies"
 )


### PR DESCRIPTION
This pull request resolves #22 by introducing a `_cdeps_parse_arguments` macro alongside its testing.