### PR TITLE
Utilize CTest Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,4 +18,4 @@ jobs:
           options: BUILD_TESTING=ON
 
       - name: Test Project
-        run: ctest -C debug --output-on-failure --test-dir build --no-tests=error
+        uses: threeal/ctest-action@v1.0.0


### PR DESCRIPTION
This pull request resolves #29 by using the [CTest Action](https://github.com/marketplace/actions/ctest-action) as a replacement for the `ctest` command to run tests for this project in the GitHub Actions workflows.