### PR TITLE
Specify CMake Minimum Version in Test Modules

### DIFF
--- a/test/CDepsParseArgsTest.cmake
+++ b/test/CDepsParseArgsTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 include(CDeps)
 
 function(expect VAR EXPECTED)

--- a/test/CDepsTest.cmake
+++ b/test/CDepsTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 function(reconfigure_project)
   message(STATUS "Reconfiguring project")
   execute_process(


### PR DESCRIPTION
This pull request resolves #43 by simply specifying the CMake minimum required version in the test modules.