### PR TITLE
Utilize Assertion.cmake

### DIFF
--- a/test/CDepsParseArgsTest.cmake
+++ b/test/CDepsParseArgsTest.cmake
@@ -1,18 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
+file(
+  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.1.0 ${CMAKE_BINARY_DIR}/Assertion.cmake
+  EXPECTED_MD5 3c9c0dd5e971bde719d7151c673e08b4
+)
+include(${CMAKE_BINARY_DIR}/Assertion.cmake)
+
 include(CDeps)
-
-function(expect VAR EXPECTED)
-  if(NOT ${VAR} STREQUAL "${EXPECTED}")
-    message(FATAL_ERROR "${VAR} expected to be equal to ${EXPECTED} but got ${${VAR}} instead")
-  endif()
-endfunction()
-
-function(expect_undefined VAR)
-  if(${VAR})
-    message(FATAL_ERROR "${VAR} should not be defined")
-  endif()
-endfunction()
 
 function("Parse arguments")
   _cdeps_parse_arguments(
@@ -24,19 +18,26 @@ function("Parse arguments")
       BUILD_DOCS=OFF
   )
 
-  expect(ARG_NAME Foo)
-  expect(ARG_GIT_URL https://github.com/foo/foo)
-  expect(ARG_GIT_TAG 1.2.3)
-  expect(ARG_OPTIONS "BUILD_TESTING=OFF;BUILD_DOCS=OFF")
+  assert_defined(ARG_NAME)
+  assert_strequal("${ARG_NAME}" Foo)
+
+  assert_defined(ARG_GIT_URL)
+  assert_strequal("${ARG_GIT_URL}" https://github.com/foo/foo)
+
+  assert_defined(ARG_GIT_TAG)
+  assert_strequal("${ARG_GIT_TAG}" 1.2.3)
+
+  assert_defined(ARG_OPTIONS)
+  assert_strequal("${ARG_OPTIONS}" "BUILD_TESTING=OFF;BUILD_DOCS=OFF")
 endfunction()
 
 function("Parse empty arguments")
   _cdeps_parse_arguments()
 
-  expect_undefined(ARG_NAME)
-  expect_undefined(ARG_GIT_URL)
-  expect_undefined(ARG_GIT_TAG)
-  expect_undefined(ARG_OPTIONS)
+  assert_not_defined(ARG_NAME)
+  assert_not_defined(ARG_GIT_URL)
+  assert_not_defined(ARG_GIT_TAG)
+  assert_not_defined(ARG_OPTIONS)
 endfunction()
 
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #47 by utilizing assertion functions from the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module during testing.