### PR TITLE
Run Sample Project During Build

### DIFF
--- a/test/CDepsTest.cmake
+++ b/test/CDepsTest.cmake
@@ -26,21 +26,9 @@ function(build_project)
   endif()
 endfunction()
 
-function(run_project)
-  message(STATUS "Running project")
-  execute_process(
-    COMMAND ${CMAKE_CURRENT_LIST_DIR}/project/build/main
-    RESULT_VARIABLE RES
-  )
-  if(NOT RES EQUAL 0)
-    message(FATAL_ERROR "Failed to run project")
-  endif()
-endfunction()
-
 function("Install missing dependencies")
   reconfigure_project()
   build_project()
-  run_project()
 endfunction()
 
 cmake_language(CALL "${TEST_COMMAND}")

--- a/test/project/CMakeLists.txt
+++ b/test/project/CMakeLists.txt
@@ -21,3 +21,6 @@ find_package(FMT REQUIRED NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
 
 add_executable(main src/main.cpp)
 target_link_libraries(main fmt::fmt)
+
+add_custom_target(run_main ALL COMMAND "$<TARGET_FILE:main>")
+add_dependencies(run_main main)


### PR DESCRIPTION
This pull request resolves #54 by adding a `run_main` target to the sample project for executing the `main` target, effectively allowing the sample project to be run during the build process. This deprecates the `run_project` function.