### PR TITLE
Improve Function Arguments Handling

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -10,7 +10,7 @@ include_guard(GLOBAL)
 #   - GIT_TAG: The Git tag of the package.
 #   - OPTIONS: The options to be passed during the build configuration of the package.
 function(cdeps_install_package)
-  cmake_parse_arguments(ARG "" "NAME;GIT_URL;GIT_TAG" "OPTIONS" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "NAME;GIT_URL;GIT_TAG" OPTIONS)
 
   # Set the default CDEPS_ROOT directory if not provided.
   if(NOT CDEPS_ROOT)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,11 @@
 function(add_cmake_test FILE)
-  foreach(NAME ${ARGN})
+  math(EXPR STOP "${ARGC} - 1")
+  foreach(I RANGE 1 "${STOP}")
     add_test(
-      NAME "${NAME}"
+      NAME "${ARGV${I}}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_COMMAND=${NAME}
+        -D "TEST_COMMAND=${ARGV${I}}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()


### PR DESCRIPTION
This pull request resolves #59 by introducing the following changes:
- Utilizes the `ARGC` and `ARGV<INDEX>` variables in the `add_cmake_test` function.
- Utilizes the `PARSE_ARGV` version of the `cmake_parse_arguments` function, replacing the standard usage which utilized `ARGN`.