### PR TITLE
Bump Assertion.cmake to Version 0.3.0

### DIFF
--- a/test/CDepsTest.cmake
+++ b/test/CDepsTest.cmake
@@ -1,24 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac
+  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a
 )
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 function("Install missing dependencies")
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}"
+    "${CMAKE_COMMAND}"
       -B ${CMAKE_CURRENT_LIST_DIR}/project/build
       -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
       --fresh
-      ${CMAKE_CURRENT_LIST_DIR}/project
-  )
+      ${CMAKE_CURRENT_LIST_DIR}/project)
 
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/project/build
-  )
+    "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/project/build)
 endfunction()
 
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request simply bumps the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [0.3.0](https://github.com/threeal/assertion-cmake/releases/tag/v0.3.0).