### PR TITLE
Utilize `PROJECT_IS_TOP_LEVEL` Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 
 project(
   CDeps
@@ -10,7 +10,7 @@ project(
 
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(PROJECT_IS_TOP_LEVEL)
   if(BUILD_TESTING)
     enable_testing()
     add_subdirectory(test)


### PR DESCRIPTION
This pull request resolves #66 by utilizing the `PROJECT_IS_TOP_LEVEL` variable, replacing the `CMAKE_CURRENT_SOURCE_DIR` and `CMAKE_SOURCE_DIR` variables comparison. This change also bumps the minimum CMake version to 3.21.