### PR TITLE
Add Option to Enable Install Targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,16 @@ project(
   LANGUAGES NONE
 )
 
+option(CDEPS_ENABLE_INSTALL "Enable install targets." ${PROJECT_IS_TOP_LEVEL})
+
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-if(PROJECT_IS_TOP_LEVEL)
-  if(BUILD_TESTING)
-    enable_testing()
-    add_subdirectory(test)
-  endif()
+if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(test)
+endif()
 
+if(CDEPS_ENABLE_INSTALL)
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     CDepsConfigVersion.cmake


### PR DESCRIPTION
This pull request resolves #65 by adding a `CDEPS_ENABLE_INSTALL` option to enable install targets in the sample project. By default, this option is enabled if the `PROJECT_IS_TOP_LEVEL` variable is also enabled.