### PR TITLE
Add Option to Enable Test Targets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: BUILD_TESTING=ON
+          options: CDEPS_ENABLE_TESTS=ON
 
       - name: Test Project
         uses: threeal/ctest-action@v1.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,12 @@ project(
   LANGUAGES NONE
 )
 
+option(CDEPS_ENABLE_TESTS "Enable test targets.")
 option(CDEPS_ENABLE_INSTALL "Enable install targets." ${PROJECT_IS_TOP_LEVEL})
 
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(CDEPS_ENABLE_TESTS)
   enable_testing()
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
This pull request resolves #69 by adding a `CDDEPS_ENABLE_TESTS` option to enable test targets in the project, replacing the `BUILD_TESTING` variable.