### PR TITLE
Modify Accepted Git URL Style

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ if(CDEPS_ENABLE_TESTS)
     EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
 
   add_test(
+    NAME "package URL resolve"
+    COMMAND "${CMAKE_COMMAND}"
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageUrlResolve.cmake)
+
+  add_test(
     NAME "package download"
     COMMAND "${CMAKE_COMMAND}"
       -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageDownload.cmake)

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -3,6 +3,20 @@
 
 include_guard(GLOBAL)
 
+# Resolves the given package URL to a valid URL.
+#
+# cdeps_resolve_package_url(<url> <output_url>)
+#
+# This function resolves the given `<url>` to a valid URL and outputs it to the
+# `<output_url>` variable.
+function(cdeps_resolve_package_url URL OUTPUT_URL)
+  if(URL MATCHES ".*://")
+    set("${OUTPUT_URL}" "${URL}" PARENT_SCOPE)
+  else()
+    set("${OUTPUT_URL}" https://${URL} PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Downloads the source code of an external package.
 #
 # cdeps_download_package(<url> [NAME <name>] [GIT_TAG <tag>])
@@ -29,9 +43,11 @@ function(cdeps_download_package URL)
       message(FATAL_ERROR "CDeps: Git is required to download packages")
     endif()
 
-    message(STATUS "CDeps: Downloading ${ARG_NAME} from ${URL}#${ARG_GIT_TAG}")
+    cdeps_resolve_package_url("${URL}" GIT_URL)
+
+    message(STATUS "CDeps: Downloading ${ARG_NAME} from ${GIT_URL}#${ARG_GIT_TAG}")
     execute_process(
-      COMMAND git clone -b "${ARG_GIT_TAG}" "https://${URL}" "${SOURCE_DIR}"
+      COMMAND git clone -b "${ARG_GIT_TAG}" "${GIT_URL}" "${SOURCE_DIR}"
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
     )

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -5,15 +5,15 @@ include_guard(GLOBAL)
 
 # Downloads the source code of an external package.
 #
-# cdeps_download_package(<git_url> [NAME <name>] [GIT_TAG <tag>])
+# cdeps_download_package(<url> [NAME <name>] [GIT_TAG <tag>])
 #
 # This function downloads the source code of an external package using Git.
-# It downloads the source code from the given `<git_url>` with a specific
-# `<tag>` and saves it as the `<name>` package.
+# It downloads the source code from the given `<url>` with a specific `<tag>`
+# and saves it as the `<name>` package.
 #
 # This function outputs the `<name>_SOURCE_DIR` variable, which contains the
 # path of the downloaded source code of the external package.
-function(cdeps_download_package GIT_URL)
+function(cdeps_download_package URL)
   cmake_parse_arguments(PARSE_ARGV 1 ARG "" "NAME;GIT_TAG" "")
 
   # Set the default CDEPS_ROOT directory if not provided.
@@ -29,9 +29,9 @@ function(cdeps_download_package GIT_URL)
       message(FATAL_ERROR "CDeps: Git is required to download packages")
     endif()
 
-    message(STATUS "CDeps: Downloading ${ARG_NAME} from ${GIT_URL}#${ARG_GIT_TAG}")
+    message(STATUS "CDeps: Downloading ${ARG_NAME} from ${URL}#${ARG_GIT_TAG}")
     execute_process(
-      COMMAND git clone -b "${ARG_GIT_TAG}" "${GIT_URL}" "${SOURCE_DIR}"
+      COMMAND git clone -b "${ARG_GIT_TAG}" "https://${URL}" "${SOURCE_DIR}"
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
     )
@@ -46,20 +46,20 @@ endfunction()
 # Builds an external package from downloaded source code.
 #
 # cdeps_build_package(
-#   <git_url> [NAME <name>] [GIT_TAG <tag>] [OPTIONS <options>...])
+#   <url> [NAME <name>] [GIT_TAG <tag>] [OPTIONS <options>...])
 #
 # This function builds an external package named `<name>` with `<options>` from
-# source code downloaded from the given `<git_url>` with a specific `<tag>`.
+# source code downloaded from the given `<url>` with a specific `<tag>`.
 #
 # This function outputs the `<name>_BUILD_DIR` variable, which contains the
 # path of the built external package.
 #
 # See also the documentation of the `cdeps_download_package` function.
-function(cdeps_build_package GIT_URL)
+function(cdeps_build_package URL)
   cmake_parse_arguments(PARSE_ARGV 1 ARG "" "NAME" OPTIONS)
 
   cdeps_download_package(
-    "${GIT_URL}" NAME "${ARG_NAME}" ${ARG_UNPARSED_ARGUMENTS})
+    "${URL}" NAME "${ARG_NAME}" ${ARG_UNPARSED_ARGUMENTS})
 
   # Set the default CDEPS_ROOT directory if not provided.
   if(NOT CDEPS_ROOT)
@@ -100,18 +100,18 @@ endfunction()
 # Installs an external package after building it from downloaded source code.
 #
 # cdeps_install_package(
-#   <git_url> [NAME <name>] [GIT_TAG <tag>] [OPTIONS <options>...])
+#   <url> [NAME <name>] [GIT_TAG <tag>] [OPTIONS <options>...])
 #
 # This function installs an external package named `<name>` after building it
-# with `<options>` from source code downloaded from the given `<git_url>` with
+# with `<options>` from source code downloaded from the given `<url>` with
 # a specific `<tag>`.
 #
 # See also the documentation of the `cdeps_download_package` and
 # `cdeps_build_package` functions.
-function(cdeps_install_package GIT_URL)
+function(cdeps_install_package URL)
   cmake_parse_arguments(PARSE_ARGV 1 ARG "" "NAME" "")
 
-  cdeps_build_package("${GIT_URL}" NAME "${ARG_NAME}" ${ARG_UNPARSED_ARGUMENTS})
+  cdeps_build_package("${URL}" NAME "${ARG_NAME}" ${ARG_UNPARSED_ARGUMENTS})
 
   # Set the default CDEPS_ROOT directory if not provided.
   if(NOT CDEPS_ROOT)

--- a/test/PackageBuild.cmake
+++ b/test/PackageBuild.cmake
@@ -14,7 +14,7 @@ section("it should fail to configure an external package build")
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
     "cdeps_build_package(\n"
-    "  https://github.com/threeal/project-starter\n"
+    "  github.com/threeal/project-starter\n"
     "  NAME project-starter\n"
     "  GIT_TAG main)\n")
 
@@ -35,7 +35,7 @@ section("it should fail to build an external package")
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
     "cdeps_build_package(\n"
-    "  https://github.com/threeal/cpp-starter\n"
+    "  github.com/threeal/cpp-starter\n"
     "  NAME cpp-starter\n"
     "  GIT_TAG main\n"
     "  OPTIONS CMAKE_CXX_FLAGS=invalid CMAKE_CXX_COMPILER_WORKS=ON)\n")
@@ -57,7 +57,7 @@ section("it should build an external package")
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
     "cdeps_build_package(\n"
-    "  https://github.com/threeal/cpp-starter\n"
+    "  github.com/threeal/cpp-starter\n"
     "  NAME cpp-starter\n"
     "  GIT_TAG main)\n"
     "\n"

--- a/test/PackageDownload.cmake
+++ b/test/PackageDownload.cmake
@@ -12,7 +12,7 @@ section("it should fail to download the source code of an external package")
     "project(Poject LANGUAGES CXX)\n"
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
-    "cdeps_download_package(https://google.com NAME google)\n")
+    "cdeps_download_package(google.com NAME google)\n")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -B project/build project
@@ -31,7 +31,7 @@ section("it should download the source code of an external package")
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
     "cdeps_download_package(\n"
-    "  https://github.com/threeal/project-starter\n"
+    "  github.com/threeal/project-starter\n"
     "  NAME project-starter\n"
     "  GIT_TAG main)\n"
     "\n"

--- a/test/PackageInstallation.cmake
+++ b/test/PackageInstallation.cmake
@@ -14,7 +14,7 @@ section("it should fail to install an external package")
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
     "cdeps_install_package(\n"
-    "  https://github.com/threeal/cpp-starter\n"
+    "  github.com/threeal/cpp-starter\n"
     "  NAME cpp-starter\n"
     "  GIT_TAG main\n"
     "  OPTIONS CMAKE_SKIP_INSTALL_RULES=ON)\n")
@@ -41,7 +41,7 @@ section("it should install an external package")
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
     "cdeps_install_package(\n"
-    "  https://github.com/threeal/cpp-starter\n"
+    "  github.com/threeal/cpp-starter\n"
     "  NAME cpp-starter\n"
     "  GIT_TAG main)\n"
     "\n"

--- a/test/PackageUrlResolve.cmake
+++ b/test/PackageUrlResolve.cmake
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+
+find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(Assertion.cmake)
+
+section("it should resolve a package URL that contains an HTTP protocol")
+  cdeps_resolve_package_url(http://github.com/threeal/cpp-starter OUTPUT)
+  assert(OUTPUT STREQUAL http://github.com/threeal/cpp-starter)
+endsection()
+
+section("it should resolve a package URL that contains an HTTPS protocol")
+  cdeps_resolve_package_url(https://github.com/threeal/cpp-starter OUTPUT)
+  assert(OUTPUT STREQUAL https://github.com/threeal/cpp-starter)
+endsection()
+
+section("it should resolve a package URL that contains no protocol")
+  cdeps_resolve_package_url(github.com/threeal/cpp-starter OUTPUT)
+  assert(OUTPUT STREQUAL https://github.com/threeal/cpp-starter)
+endsection()


### PR DESCRIPTION
This pull request resolves #73 by modifying the accepted Git URL style in the `cdeps_install_package` function to also accept URLs without a protocol (e.g., `github.com/fmtlib/fmt`). This change also introduces a `cdeps_resolve_package_url` function for resolving the given package URL into a valid URL.