### PR TITLE
Separate Package Download and Build Functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,14 @@ if(CDEPS_ENABLE_TESTS)
     EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
 
   add_test(
-    NAME "dependencies installation"
+    NAME "package download"
     COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/DepsInstallation.cmake)
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageDownload.cmake)
+
+  add_test(
+    NAME "package installation"
+    COMMAND "${CMAKE_COMMAND}"
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageInstallation.cmake)
 endif()
 
 if(CDEPS_ENABLE_INSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ if(CDEPS_ENABLE_TESTS)
       -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageDownload.cmake)
 
   add_test(
+    NAME "package build"
+    COMMAND "${CMAKE_COMMAND}"
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageBuild.cmake)
+
+  add_test(
     NAME "package installation"
     COMMAND "${CMAKE_COMMAND}"
       -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageInstallation.cmake)

--- a/test/PackageBuild.cmake
+++ b/test/PackageBuild.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 include(Assertion.cmake)
 
-section("it should fail to install an external package")
+section("it should fail to configure an external package build")
   file(REMOVE_RECURSE project)
   file(MAKE_DIRECTORY project)
 
@@ -13,18 +13,17 @@ section("it should fail to install an external package")
     "project(Poject LANGUAGES CXX)\n"
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
-    "cdeps_install_package(\n"
-    "  https://github.com/threeal/cpp-starter\n"
-    "  NAME cpp-starter\n"
-    "  GIT_TAG main\n"
-    "  OPTIONS CMAKE_SKIP_INSTALL_RULES=ON)\n")
+    "cdeps_build_package(\n"
+    "  https://github.com/threeal/project-starter\n"
+    "  NAME project-starter\n"
+    "  GIT_TAG main)\n")
 
   assert_execute_process(
     COMMAND "${CMAKE_COMMAND}" -B project/build project
-    ERROR "CDeps: Failed to install cpp-starter:")
+    ERROR "CDeps: Failed to configure project-starter:")
 endsection()
 
-section("it should install an external package")
+section("it should fail to build an external package")
   file(REMOVE_RECURSE project)
   file(MAKE_DIRECTORY project)
 
@@ -34,39 +33,37 @@ section("it should install an external package")
     "cmake_minimum_required(VERSION 3.5)\n"
     "project(Poject LANGUAGES CXX)\n"
     "\n"
-    "include(../Assertion.cmake)\n"
-    "\n"
-    "find_package(MyFibonacci QUIET)\n"
-    "assert(NOT MyFibonacci_FOUND)\n"
+    "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
+    "cdeps_build_package(\n"
+    "  https://github.com/threeal/cpp-starter\n"
+    "  NAME cpp-starter\n"
+    "  GIT_TAG main\n"
+    "  OPTIONS CMAKE_CXX_FLAGS=invalid CMAKE_CXX_COMPILER_WORKS=ON)\n")
+
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" -B project/build project
+    ERROR "CDeps: Failed to build cpp-starter:")
+endsection()
+
+section("it should build an external package")
+  file(REMOVE_RECURSE project)
+  file(MAKE_DIRECTORY project)
+
+  # TODO: Currently, a Git tag is always required.
+  file(
+    WRITE project/CMakeLists.txt
+    "cmake_minimum_required(VERSION 3.5)\n"
+    "project(Poject LANGUAGES CXX)\n"
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
-    "cdeps_install_package(\n"
+    "cdeps_build_package(\n"
     "  https://github.com/threeal/cpp-starter\n"
     "  NAME cpp-starter\n"
     "  GIT_TAG main)\n"
     "\n"
-    "find_package(MyFibonacci REQUIRED)\n"
-    "\n"
-    "add_executable(main main.cpp)\n"
-    "target_link_libraries(main my_fibonacci::sequence)\n"
-    "\n"
-    "add_custom_target(run_main ALL COMMAND \"$<TARGET_FILE:main>\")\n"
-    "add_dependencies(run_main main)\n")
-
-  file(
-    WRITE project/main.cpp
-    "#include <my_fibonacci/sequence.hpp>\n"
-    "#include <iostream>\n"
-    "\n"
-    "int main() {\n"
-    "  const auto sequence = my_fibonacci::fibonacci_sequence(5);\n"
-    "  for (auto val : sequence) {\n"
-    "    std::cout << val << \" \";\n"
-    "  }\n"
-    "  std::cout << std::endl;\n"
-    "  return 0;\n"
-    "}\n")
+    "include(../Assertion.cmake)\n"
+    "assert(DEFINED cpp-starter_BUILD_DIR)\n"
+    "assert(EXISTS \"\${cpp-starter_BUILD_DIR}\")\n")
 
   assert_execute_process("${CMAKE_COMMAND}" -B project/build project)
-  assert_execute_process("${CMAKE_COMMAND}" --build project/build)
 endsection()

--- a/test/PackageDownload.cmake
+++ b/test/PackageDownload.cmake
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.5)
+
+include(Assertion.cmake)
+
+section("it should fail to download the source code of an external package")
+  file(REMOVE_RECURSE project)
+  file(MAKE_DIRECTORY project)
+
+  file(
+    WRITE project/CMakeLists.txt
+    "cmake_minimum_required(VERSION 3.5)\n"
+    "project(Poject LANGUAGES CXX)\n"
+    "\n"
+    "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
+    "cdeps_download_package(https://google.com NAME google)\n")
+
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" -B project/build project
+    ERROR "CDeps: Failed to download google:")
+endsection()
+
+section("it should download the source code of an external package")
+  file(REMOVE_RECURSE project)
+  file(MAKE_DIRECTORY project)
+
+  # TODO: Currently, a Git tag is always required.
+  file(
+    WRITE project/CMakeLists.txt
+    "cmake_minimum_required(VERSION 3.5)\n"
+    "project(Poject LANGUAGES CXX)\n"
+    "\n"
+    "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
+    "cdeps_download_package(\n"
+    "  https://github.com/threeal/project-starter\n"
+    "  NAME project-starter\n"
+    "  GIT_TAG main)\n"
+    "\n"
+    "include(../Assertion.cmake)\n"
+    "assert(DEFINED project-starter_SOURCE_DIR)\n"
+    "assert(EXISTS \"\${project-starter_SOURCE_DIR}\")\n")
+
+  assert_execute_process(COMMAND "${CMAKE_COMMAND}" -B project/build project)
+endsection()

--- a/test/PackageInstallation.cmake
+++ b/test/PackageInstallation.cmake
@@ -2,24 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 include(Assertion.cmake)
 
-section("it should fail to download a dependency")
-  file(REMOVE_RECURSE project)
-  file(MAKE_DIRECTORY project)
-
-  file(
-    WRITE project/CMakeLists.txt
-    "cmake_minimum_required(VERSION 3.5)\n"
-    "project(Poject LANGUAGES CXX)\n"
-    "\n"
-    "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
-    "cdeps_install_package(https://google.com NAME google)\n")
-
-  assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}" -B project/build project
-    ERROR "CDeps: Failed to download google:")
-endsection()
-
-section("it should fail to configure a dependency")
+section("it should fail to configure an external package")
   file(REMOVE_RECURSE project)
   file(MAKE_DIRECTORY project)
 
@@ -40,7 +23,7 @@ section("it should fail to configure a dependency")
     ERROR "CDeps: Failed to configure project-starter:")
 endsection()
 
-section("it should fail to build a dependency")
+section("it should fail to build an external package")
   file(REMOVE_RECURSE project)
   file(MAKE_DIRECTORY project)
 
@@ -62,7 +45,7 @@ section("it should fail to build a dependency")
     ERROR "CDeps: Failed to build cpp-starter:")
 endsection()
 
-section("it should fail to install a dependency")
+section("it should fail to install an external package")
   file(REMOVE_RECURSE project)
   file(MAKE_DIRECTORY project)
 
@@ -84,7 +67,7 @@ section("it should fail to install a dependency")
     ERROR "CDeps: Failed to install cmake-starter:")
 endsection()
 
-section("it should install a dependency")
+section("it should install an external package")
   file(REMOVE_RECURSE project)
   file(MAKE_DIRECTORY project)
 


### PR DESCRIPTION
This pull request resolves #81 by separating the `cdep_download_package` and `cdep_build_package` functions from the `cdep_install_package` function. It also modifies the tests accordingly.