### PR TITLE
Treat Package URL as Package Name

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -38,16 +38,15 @@ endfunction()
 
 # Downloads the source code of an external package.
 #
-# cdeps_download_package(<url> [NAME <name>] [GIT_TAG <tag>])
+# cdeps_download_package(<url> [GIT_TAG <tag>])
 #
 # This function downloads the source code of an external package using Git.
-# It downloads the source code from the given `<url>` with a specific `<tag>`
-# and saves it as the `<name>` package.
+# It downloads the source code from the given `<url>` with a specific `<tag>`.
 #
-# This function outputs the `<name>_SOURCE_DIR` variable, which contains the
+# This function outputs the `<url>_SOURCE_DIR` variable, which contains the
 # path of the downloaded source code of the external package.
 function(cdeps_download_package URL)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "NAME;GIT_TAG" "")
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "GIT_TAG" "")
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
   # Check if the source directory exists; if not, download the package using Git.
@@ -62,7 +61,7 @@ function(cdeps_download_package URL)
 
     cdeps_resolve_package_url("${URL}" GIT_URL)
 
-    message(STATUS "CDeps: Downloading ${ARG_NAME} from ${GIT_URL}#${ARG_GIT_TAG}")
+    message(STATUS "CDeps: Downloading ${URL} from ${GIT_URL}#${ARG_GIT_TAG}")
     execute_process(
       COMMAND "${GIT_EXECUTABLE}" clone -b "${ARG_GIT_TAG}" "${GIT_URL}"
         ${PACKAGE_DIR}-src
@@ -71,12 +70,12 @@ function(cdeps_download_package URL)
     )
     if(NOT "${RES}" EQUAL 0)
       file(REMOVE_RECURSE ${PACKAGE_DIR}-src)
-      message(FATAL_ERROR "CDeps: Failed to download ${ARG_NAME}: ${ERR}")
+      message(FATAL_ERROR "CDeps: Failed to download ${URL}: ${ERR}")
       return()
     endif()
   endif()
 
-  set(${ARG_NAME}_SOURCE_DIR ${PACKAGE_DIR}-src PARENT_SCOPE)
+  set(${URL}_SOURCE_DIR ${PACKAGE_DIR}-src PARENT_SCOPE)
 endfunction()
 
 # Builds an external package from downloaded source code.
@@ -95,8 +94,7 @@ function(cdeps_build_package URL)
   cmake_parse_arguments(PARSE_ARGV 1 ARG "" "NAME" OPTIONS)
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
-  cdeps_download_package(
-    "${URL}" NAME "${ARG_NAME}" ${ARG_UNPARSED_ARGUMENTS})
+  cdeps_download_package("${URL}" ${ARG_UNPARSED_ARGUMENTS})
 
   # Check if the build directory exists; if not, configure and build the package.
   if(NOT EXISTS ${PACKAGE_DIR}-build)
@@ -106,7 +104,7 @@ function(cdeps_build_package URL)
     endforeach()
     execute_process(
       COMMAND "${CMAKE_COMMAND}" -B ${PACKAGE_DIR}-build ${CONFIGURE_ARGS}
-        "${${ARG_NAME}_SOURCE_DIR}"
+        "${${URL}_SOURCE_DIR}"
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
     )

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -131,24 +131,22 @@ endfunction()
 
 # Installs an external package after building it from downloaded source code.
 #
-# cdeps_install_package(
-#   <url> [NAME <name>] [GIT_TAG <tag>] [OPTIONS <options>...])
+# cdeps_install_package(<url> [GIT_TAG <tag>] [OPTIONS <options>...])
 #
-# This function installs an external package named `<name>` after building it
-# with `<options>` from source code downloaded from the given `<url>` with
-# a specific `<tag>`.
+# This function installs an external package after building it with `<options>`
+# from source code downloaded from the given `<url>` with a specific `<tag>`.
 #
 # See also the documentation of the `cdeps_download_package` and
 # `cdeps_build_package` functions.
 function(cdeps_install_package URL)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "NAME" "")
+  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" "")
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
   cdeps_build_package("${URL}" ${ARG_UNPARSED_ARGUMENTS})
 
   # Check if the installation directory exists; if not, install the package.
   if(NOT EXISTS ${PACKAGE_DIR}-install)
-    message(STATUS "CDeps: Installing ${ARG_NAME}")
+    message(STATUS "CDeps: Installing ${URL}")
     execute_process(
       COMMAND "${CMAKE_COMMAND}" --install "${${URL}_BUILD_DIR}"
         --prefix ${PACKAGE_DIR}-install
@@ -157,7 +155,7 @@ function(cdeps_install_package URL)
     )
     if(NOT "${RES}" EQUAL 0)
       file(REMOVE_RECURSE ${PACKAGE_DIR}-install)
-      message(FATAL_ERROR "CDeps: Failed to install ${ARG_NAME}: ${ERR}")
+      message(FATAL_ERROR "CDeps: Failed to install ${URL}: ${ERR}")
       return()
     endif()
   endif()

--- a/test/PackageBuild.cmake
+++ b/test/PackageBuild.cmake
@@ -11,7 +11,7 @@ section("it should fail to configure an external package build")
   assert_fatal_error(
     CALL cdeps_build_package github.com/threeal/project-starter
       NAME project-starter GIT_TAG main
-    MESSAGE "CDeps: Failed to configure project-starter:")
+    MESSAGE "CDeps: Failed to configure github.com/threeal/project-starter:")
 endsection()
 
 section("it should fail to build an external package")
@@ -20,7 +20,7 @@ section("it should fail to build an external package")
     CALL cdeps_build_package github.com/threeal/cpp-starter
       NAME cpp-starter GIT_TAG main
       OPTIONS CMAKE_CXX_FLAGS=invalid CMAKE_CXX_COMPILER_WORKS=ON
-    MESSAGE "CDeps: Failed to build cpp-starter:")
+    MESSAGE "CDeps: Failed to build github.com/threeal/cpp-starter:")
 endsection()
 
 section("it should build an external package")
@@ -30,6 +30,6 @@ section("it should build an external package")
     NAME cpp-starter
     GIT_TAG main)
 
-  assert(DEFINED cpp-starter_BUILD_DIR)
-  assert(EXISTS "${cpp-starter_BUILD_DIR}")
+  assert(DEFINED github.com/threeal/cpp-starter_BUILD_DIR)
+  assert(EXISTS "${github.com/threeal/cpp-starter_BUILD_DIR}")
 endsection()

--- a/test/PackageDownload.cmake
+++ b/test/PackageDownload.cmake
@@ -8,17 +8,14 @@ file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
 section("it should fail to download the source code of an external package")
   assert_fatal_error(
-    CALL cdeps_download_package google.com NAME google
-    MESSAGE "CDeps: Failed to download google:")
+    CALL cdeps_download_package google.com
+    MESSAGE "CDeps: Failed to download google.com:")
 endsection()
 
 section("it should download the source code of an external package")
   # TODO: Currently, a Git tag is always required.
-  cdeps_download_package(
-    github.com/threeal/project-starter
-    NAME project-starter
-    GIT_TAG main)
+  cdeps_download_package(github.com/threeal/project-starter GIT_TAG main)
 
-  assert(DEFINED project-starter_SOURCE_DIR)
-  assert(EXISTS "${project-starter_SOURCE_DIR}")
+  assert(DEFINED github.com/threeal/project-starter_SOURCE_DIR)
+  assert(EXISTS "${github.com/threeal/project-starter_SOURCE_DIR}")
 endsection()

--- a/test/PackageInstallation.cmake
+++ b/test/PackageInstallation.cmake
@@ -10,7 +10,7 @@ section("it should fail to install an external package")
   assert_fatal_error(
     CALL cdeps_install_package github.com/threeal/cpp-starter
       NAME cpp-starter GIT_TAG main OPTIONS CMAKE_SKIP_INSTALL_RULES=ON
-    MESSAGE "CDeps: Failed to install cpp-starter:")
+    MESSAGE "CDeps: Failed to install github.com/threeal/cpp-starter:")
 endsection()
 
 section("it should install an external package")


### PR DESCRIPTION
This pull request resolves #89 by modifying the `cdeps_download_package`, `cdeps_build_package`, and `cdeps_install_package` functions to treat the package URL as the package name, effectively removing the need to specify the package name.