### PR TITLE
Simplify Package Functions Arguments

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -38,15 +38,15 @@ endfunction()
 
 # Downloads the source code of an external package.
 #
-# cdeps_download_package(<url> [GIT_TAG <tag>])
+# cdeps_download_package(<url> <ref>)
 #
 # This function downloads the source code of an external package using Git.
-# It downloads the source code from the given `<url>` with a specific `<tag>`.
+# It downloads the source code from the specified `<url>` with a particular
+# `<ref>`. The `<ref>` can be a branch, tag, or commit hash.
 #
 # This function outputs the `<url>_SOURCE_DIR` variable, which contains the
 # path of the downloaded source code of the external package.
-function(cdeps_download_package URL)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "GIT_TAG" "")
+function(cdeps_download_package URL REF)
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
   # Check if the source directory exists; if not, download the package using Git.
@@ -61,9 +61,9 @@ function(cdeps_download_package URL)
 
     cdeps_resolve_package_url("${URL}" GIT_URL)
 
-    message(STATUS "CDeps: Downloading ${URL} from ${GIT_URL}#${ARG_GIT_TAG}")
+    message(STATUS "CDeps: Downloading ${URL} from ${GIT_URL} at ${REF}")
     execute_process(
-      COMMAND "${GIT_EXECUTABLE}" clone -b "${ARG_GIT_TAG}" "${GIT_URL}"
+      COMMAND "${GIT_EXECUTABLE}" clone -b "${REF}" "${GIT_URL}"
         ${PACKAGE_DIR}-src
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
@@ -80,20 +80,20 @@ endfunction()
 
 # Builds an external package from downloaded source code.
 #
-# cdeps_build_package(<url> [GIT_TAG <tag>] [OPTIONS <options>...])
+# cdeps_build_package(<url> <ref> [OPTIONS <options>...])
 #
 # This function builds an external package with `<options>` from source code
-# downloaded from the given `<url>` with a specific `<tag>`.
+# downloaded from the specified `<url>` with a particular `<ref>`.
 #
 # This function outputs the `<url>_BUILD_DIR` variable, which contains the
 # path of the built external package.
 #
 # See also the documentation of the `cdeps_download_package` function.
-function(cdeps_build_package URL)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" OPTIONS)
+function(cdeps_build_package URL REF)
+  cmake_parse_arguments(PARSE_ARGV 2 ARG "" "" OPTIONS)
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
-  cdeps_download_package("${URL}" ${ARG_UNPARSED_ARGUMENTS})
+  cdeps_download_package("${URL}" "${REF}" ${ARG_UNPARSED_ARGUMENTS})
 
   # Check if the build directory exists; if not, configure and build the package.
   if(NOT EXISTS ${PACKAGE_DIR}-build)
@@ -131,21 +131,22 @@ endfunction()
 
 # Installs an external package after building it from downloaded source code.
 #
-# cdeps_install_package(<url> [GIT_TAG <tag>] [OPTIONS <options>...])
+# cdeps_install_package(<url> <ref> [OPTIONS <options>...])
 #
 # This function installs an external package after building it with `<options>`
-# from source code downloaded from the given `<url>` with a specific `<tag>`.
+# from source code downloaded from the specified `<url>` with a particular
+# `<ref>`.
 #
 # This function outputs the `<url>_INSTALL_DIR` variable, which contains the
 # path of the installed external package.
 #
 # See also the documentation of the `cdeps_download_package` and
 # `cdeps_build_package` functions.
-function(cdeps_install_package URL)
-  cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" "")
+function(cdeps_install_package URL REF)
+  cmake_parse_arguments(PARSE_ARGV 2 ARG "" "" "")
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
-  cdeps_build_package("${URL}" ${ARG_UNPARSED_ARGUMENTS})
+  cdeps_build_package("${URL}" "${REF}" ${ARG_UNPARSED_ARGUMENTS})
 
   # Check if the installation directory exists; if not, install the package.
   if(NOT EXISTS ${PACKAGE_DIR}-install)

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -38,15 +38,15 @@ endfunction()
 
 # Downloads the source code of an external package.
 #
-# cdeps_download_package(<url> <ref>)
+# cdeps_download_package(<name> <url> <ref>)
 #
-# This function downloads the source code of an external package using Git.
-# It downloads the source code from the specified `<url>` with a particular
-# `<ref>`. The `<ref>` can be a branch, tag, or commit hash.
+# This function downloads the source code of an external package named `<name>`
+# using Git. It downloads the source code from the specified `<url>` with a
+# particular `<ref>`. The `<ref>` can be a branch, tag, or commit hash.
 #
-# This function outputs the `<url>_SOURCE_DIR` variable, which contains the
+# This function outputs the `<name>_SOURCE_DIR` variable, which contains the
 # path of the downloaded source code of the external package.
-function(cdeps_download_package URL REF)
+function(cdeps_download_package NAME URL REF)
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
   # Check if the source directory exists; if not, download the package using Git.
@@ -61,7 +61,7 @@ function(cdeps_download_package URL REF)
 
     cdeps_resolve_package_url("${URL}" GIT_URL)
 
-    message(STATUS "CDeps: Downloading ${URL} from ${GIT_URL} at ${REF}")
+    message(STATUS "CDeps: Downloading ${NAME} from ${GIT_URL} at ${REF}")
     execute_process(
       COMMAND "${GIT_EXECUTABLE}" clone -b "${REF}" "${GIT_URL}"
         ${PACKAGE_DIR}-src
@@ -70,50 +70,50 @@ function(cdeps_download_package URL REF)
     )
     if(NOT "${RES}" EQUAL 0)
       file(REMOVE_RECURSE ${PACKAGE_DIR}-src)
-      message(FATAL_ERROR "CDeps: Failed to download ${URL}: ${ERR}")
+      message(FATAL_ERROR "CDeps: Failed to download ${NAME}: ${ERR}")
       return()
     endif()
   endif()
 
-  set(${URL}_SOURCE_DIR ${PACKAGE_DIR}-src PARENT_SCOPE)
+  set(${NAME}_SOURCE_DIR ${PACKAGE_DIR}-src PARENT_SCOPE)
 endfunction()
 
 # Builds an external package from downloaded source code.
 #
-# cdeps_build_package(<url> <ref> [OPTIONS <options>...])
+# cdeps_build_package(<name> <url> <ref> [OPTIONS <options>...])
 #
-# This function builds an external package with `<options>` from source code
-# downloaded from the specified `<url>` with a particular `<ref>`.
+# This function builds an external package named `<name>` with `<options>` from
+# source code downloaded from the specified `<url>` with a particular `<ref>`.
 #
-# This function outputs the `<url>_BUILD_DIR` variable, which contains the
-# path of the built external package.
+# This function outputs the `<name>_BUILD_DIR` variable, which contains the path
+# of the built external package.
 #
 # See also the documentation of the `cdeps_download_package` function.
-function(cdeps_build_package URL REF)
+function(cdeps_build_package NAME URL REF)
   cmake_parse_arguments(PARSE_ARGV 2 ARG "" "" OPTIONS)
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
-  cdeps_download_package("${URL}" "${REF}" ${ARG_UNPARSED_ARGUMENTS})
+  cdeps_download_package("${NAME}" "${URL}" "${REF}" ${ARG_UNPARSED_ARGUMENTS})
 
   # Check if the build directory exists; if not, configure and build the package.
   if(NOT EXISTS ${PACKAGE_DIR}-build)
-    message(STATUS "CDeps: Configuring ${URL}")
+    message(STATUS "CDeps: Configuring ${NAME}")
     foreach(OPTION ${ARG_OPTIONS})
       list(APPEND CONFIGURE_ARGS -D "${OPTION}")
     endforeach()
     execute_process(
       COMMAND "${CMAKE_COMMAND}" -B ${PACKAGE_DIR}-build ${CONFIGURE_ARGS}
-        "${${URL}_SOURCE_DIR}"
+        "${${NAME}_SOURCE_DIR}"
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
     )
     if(NOT "${RES}" EQUAL 0)
       file(REMOVE_RECURSE ${PACKAGE_DIR}-build)
-      message(FATAL_ERROR "CDeps: Failed to configure ${URL}: ${ERR}")
+      message(FATAL_ERROR "CDeps: Failed to configure ${NAME}: ${ERR}")
       return()
     endif()
 
-    message(STATUS "CDeps: Building ${URL}")
+    message(STATUS "CDeps: Building ${NAME}")
     execute_process(
       COMMAND "${CMAKE_COMMAND}" --build ${PACKAGE_DIR}-build
       ERROR_VARIABLE ERR
@@ -121,48 +121,48 @@ function(cdeps_build_package URL REF)
     )
     if(NOT "${RES}" EQUAL 0)
       file(REMOVE_RECURSE ${PACKAGE_DIR}-build)
-      message(FATAL_ERROR "CDeps: Failed to build ${URL}: ${ERR}")
+      message(FATAL_ERROR "CDeps: Failed to build ${NAME}: ${ERR}")
       return()
     endif()
   endif()
 
-  set(${URL}_BUILD_DIR ${PACKAGE_DIR}-build PARENT_SCOPE)
+  set(${NAME}_BUILD_DIR ${PACKAGE_DIR}-build PARENT_SCOPE)
 endfunction()
 
 # Installs an external package after building it from downloaded source code.
 #
-# cdeps_install_package(<url> <ref> [OPTIONS <options>...])
+# cdeps_install_package(<name> <url> <ref> [OPTIONS <options>...])
 #
-# This function installs an external package after building it with `<options>`
-# from source code downloaded from the specified `<url>` with a particular
-# `<ref>`.
+# This function installs an external package named `<name>` after building it
+# with `<options>` from source code downloaded from the specified `<url>` with
+# a particular `<ref>`.
 #
 # This function outputs the `<url>_INSTALL_DIR` variable, which contains the
 # path of the installed external package.
 #
 # See also the documentation of the `cdeps_download_package` and
 # `cdeps_build_package` functions.
-function(cdeps_install_package URL REF)
+function(cdeps_install_package NAME URL REF)
   cmake_parse_arguments(PARSE_ARGV 2 ARG "" "" "")
   cdeps_get_package_dir("${URL}" PACKAGE_DIR)
 
-  cdeps_build_package("${URL}" "${REF}" ${ARG_UNPARSED_ARGUMENTS})
+  cdeps_build_package("${NAME}" "${URL}" "${REF}" ${ARG_UNPARSED_ARGUMENTS})
 
   # Check if the installation directory exists; if not, install the package.
   if(NOT EXISTS ${PACKAGE_DIR}-install)
-    message(STATUS "CDeps: Installing ${URL}")
+    message(STATUS "CDeps: Installing ${NAME}")
     execute_process(
-      COMMAND "${CMAKE_COMMAND}" --install "${${URL}_BUILD_DIR}"
+      COMMAND "${CMAKE_COMMAND}" --install "${${NAME}_BUILD_DIR}"
         --prefix ${PACKAGE_DIR}-install
       ERROR_VARIABLE ERR
       RESULT_VARIABLE RES
     )
     if(NOT "${RES}" EQUAL 0)
       file(REMOVE_RECURSE ${PACKAGE_DIR}-install)
-      message(FATAL_ERROR "CDeps: Failed to install ${URL}: ${ERR}")
+      message(FATAL_ERROR "CDeps: Failed to install ${NAME}: ${ERR}")
       return()
     endif()
   endif()
 
-  set(${URL}_INSTALL_DIR ${PACKAGE_DIR}-install PARENT_SCOPE)
+  set(${NAME}_INSTALL_DIR ${PACKAGE_DIR}-install PARENT_SCOPE)
 endfunction()

--- a/test/PackageBuild.cmake
+++ b/test/PackageBuild.cmake
@@ -8,20 +8,21 @@ file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
 section("it should fail to configure an external package build")
   assert_fatal_error(
-    CALL cdeps_build_package github.com/threeal/project-starter main
-    MESSAGE "CDeps: Failed to configure github.com/threeal/project-starter:")
+    CALL cdeps_build_package
+      ProjectStarter github.com/threeal/project-starter main
+    MESSAGE "CDeps: Failed to configure ProjectStarter:")
 endsection()
 
 section("it should fail to build an external package")
   assert_fatal_error(
-    CALL cdeps_build_package github.com/threeal/cpp-starter main
+    CALL cdeps_build_package CppStarter github.com/threeal/cpp-starter main
       OPTIONS CMAKE_CXX_FLAGS=invalid CMAKE_CXX_COMPILER_WORKS=ON
-    MESSAGE "CDeps: Failed to build github.com/threeal/cpp-starter:")
+    MESSAGE "CDeps: Failed to build CppStarter:")
 endsection()
 
 section("it should build an external package")
-  cdeps_build_package(github.com/threeal/cpp-starter main)
+  cdeps_build_package(CppStarter github.com/threeal/cpp-starter main)
 
-  assert(DEFINED github.com/threeal/cpp-starter_BUILD_DIR)
-  assert(EXISTS "${github.com/threeal/cpp-starter_BUILD_DIR}")
+  assert(DEFINED CppStarter_BUILD_DIR)
+  assert(EXISTS "${CppStarter_BUILD_DIR}")
 endsection()

--- a/test/PackageBuild.cmake
+++ b/test/PackageBuild.cmake
@@ -7,28 +7,20 @@ set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
 section("it should fail to configure an external package build")
-  # TODO: Currently, a Git tag is always required.
   assert_fatal_error(
-    CALL cdeps_build_package github.com/threeal/project-starter
-      NAME project-starter GIT_TAG main
+    CALL cdeps_build_package github.com/threeal/project-starter main
     MESSAGE "CDeps: Failed to configure github.com/threeal/project-starter:")
 endsection()
 
 section("it should fail to build an external package")
-  # TODO: Currently, a Git tag is always required.
   assert_fatal_error(
-    CALL cdeps_build_package github.com/threeal/cpp-starter
-      NAME cpp-starter GIT_TAG main
+    CALL cdeps_build_package github.com/threeal/cpp-starter main
       OPTIONS CMAKE_CXX_FLAGS=invalid CMAKE_CXX_COMPILER_WORKS=ON
     MESSAGE "CDeps: Failed to build github.com/threeal/cpp-starter:")
 endsection()
 
 section("it should build an external package")
-  # TODO: Currently, a Git tag is always required.
-  cdeps_build_package(
-    github.com/threeal/cpp-starter
-    NAME cpp-starter
-    GIT_TAG main)
+  cdeps_build_package(github.com/threeal/cpp-starter main)
 
   assert(DEFINED github.com/threeal/cpp-starter_BUILD_DIR)
   assert(EXISTS "${github.com/threeal/cpp-starter_BUILD_DIR}")

--- a/test/PackageDownload.cmake
+++ b/test/PackageDownload.cmake
@@ -8,13 +8,13 @@ file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
 section("it should fail to download the source code of an external package")
   assert_fatal_error(
-    CALL cdeps_download_package google.com main
-    MESSAGE "CDeps: Failed to download google.com:")
+    CALL cdeps_download_package Google google.com main
+    MESSAGE "CDeps: Failed to download Google:")
 endsection()
 
 section("it should download the source code of an external package")
-  cdeps_download_package(github.com/threeal/project-starter main)
+  cdeps_download_package(ProjectStarter github.com/threeal/project-starter main)
 
-  assert(DEFINED github.com/threeal/project-starter_SOURCE_DIR)
-  assert(EXISTS "${github.com/threeal/project-starter_SOURCE_DIR}")
+  assert(DEFINED ProjectStarter_SOURCE_DIR)
+  assert(EXISTS "${ProjectStarter_SOURCE_DIR}")
 endsection()

--- a/test/PackageDownload.cmake
+++ b/test/PackageDownload.cmake
@@ -8,13 +8,12 @@ file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
 section("it should fail to download the source code of an external package")
   assert_fatal_error(
-    CALL cdeps_download_package google.com
+    CALL cdeps_download_package google.com main
     MESSAGE "CDeps: Failed to download google.com:")
 endsection()
 
 section("it should download the source code of an external package")
-  # TODO: Currently, a Git tag is always required.
-  cdeps_download_package(github.com/threeal/project-starter GIT_TAG main)
+  cdeps_download_package(github.com/threeal/project-starter main)
 
   assert(DEFINED github.com/threeal/project-starter_SOURCE_DIR)
   assert(EXISTS "${github.com/threeal/project-starter_SOURCE_DIR}")

--- a/test/PackageInstallation.cmake
+++ b/test/PackageInstallation.cmake
@@ -8,8 +8,8 @@ file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
 section("it should fail to install an external package")
   assert_fatal_error(
-    CALL cdeps_install_package github.com/threeal/cpp-starter
-      NAME cpp-starter GIT_TAG main OPTIONS CMAKE_SKIP_INSTALL_RULES=ON
+    CALL cdeps_install_package github.com/threeal/cpp-starter main
+      OPTIONS CMAKE_SKIP_INSTALL_RULES=ON
     MESSAGE "CDeps: Failed to install github.com/threeal/cpp-starter:")
 endsection()
 
@@ -17,7 +17,6 @@ section("it should install an external package")
   file(REMOVE_RECURSE project)
   file(MAKE_DIRECTORY project)
 
-  # TODO: Currently, a Git tag is always required.
   file(
     WRITE project/CMakeLists.txt
     "cmake_minimum_required(VERSION 3.5)\n"
@@ -30,10 +29,7 @@ section("it should install an external package")
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
     "\n"
-    "cdeps_install_package(\n"
-    "  github.com/threeal/cpp-starter\n"
-    "  NAME cpp-starter\n"
-    "  GIT_TAG main)\n"
+    "cdeps_install_package(github.com/threeal/cpp-starter main)\n"
     "\n"
     "assert(DEFINED github.com/threeal/cpp-starter_INSTALL_DIR)\n"
     "assert(EXISTS \"\${github.com/threeal/cpp-starter_INSTALL_DIR}\")\n"

--- a/test/PackageInstallation.cmake
+++ b/test/PackageInstallation.cmake
@@ -8,9 +8,9 @@ file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
 section("it should fail to install an external package")
   assert_fatal_error(
-    CALL cdeps_install_package github.com/threeal/cpp-starter main
+    CALL cdeps_install_package CppStarter github.com/threeal/cpp-starter main
       OPTIONS CMAKE_SKIP_INSTALL_RULES=ON
-    MESSAGE "CDeps: Failed to install github.com/threeal/cpp-starter:")
+    MESSAGE "CDeps: Failed to install CppStarter:")
 endsection()
 
 section("it should install an external package")
@@ -29,14 +29,14 @@ section("it should install an external package")
     "\n"
     "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
     "\n"
-    "cdeps_install_package(github.com/threeal/cpp-starter main)\n"
+    "cdeps_install_package(CppStarter github.com/threeal/cpp-starter main)\n"
     "\n"
-    "assert(DEFINED github.com/threeal/cpp-starter_INSTALL_DIR)\n"
-    "assert(EXISTS \"\${github.com/threeal/cpp-starter_INSTALL_DIR}\")\n"
+    "assert(DEFINED CppStarter_INSTALL_DIR)\n"
+    "assert(EXISTS \"\${CppStarter_INSTALL_DIR}\")\n"
     "\n"
     "find_package(\n"
     "  MyFibonacci REQUIRED\n"
-    "  HINTS \"\${github.com/threeal/cpp-starter_INSTALL_DIR}\")\n"
+    "  HINTS \"\${CppStarter_INSTALL_DIR}\")\n"
     "\n"
     "add_executable(main main.cpp)\n"
     "target_link_libraries(main my_fibonacci::sequence)\n"


### PR DESCRIPTION
This pull request resolves #98 by modifying the `cdeps_download_package`, `cdeps_build_package`, and `cdeps_install_package` functions as follows:
- Modify the `GIT_TAG` option to be a `REF` argument.
- Add a `NAME` argument.