### PR TITLE
Separate Package Installation and Package Integration Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ if(CDEPS_ENABLE_TESTS)
     NAME "package installation"
     COMMAND "${CMAKE_COMMAND}"
       -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageInstallation.cmake)
+
+  add_test(
+    NAME "package integration"
+    COMMAND "${CMAKE_COMMAND}"
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageInstegration.cmake)
 endif()
 
 if(CDEPS_ENABLE_INSTALL)

--- a/test/PackageInstallation.cmake
+++ b/test/PackageInstallation.cmake
@@ -14,50 +14,11 @@ section("it should fail to install an external package")
 endsection()
 
 section("it should install an external package")
-  file(REMOVE_RECURSE project)
-  file(MAKE_DIRECTORY project)
+  # TODO: Need to reset the CDeps directory.
+  file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
-  file(
-    WRITE project/CMakeLists.txt
-    "cmake_minimum_required(VERSION 3.5)\n"
-    "project(Poject LANGUAGES CXX)\n"
-    "\n"
-    "include(../Assertion.cmake)\n"
-    "\n"
-    "find_package(MyFibonacci QUIET)\n"
-    "assert(NOT MyFibonacci_FOUND)\n"
-    "\n"
-    "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
-    "\n"
-    "cdeps_install_package(CppStarter github.com/threeal/cpp-starter main)\n"
-    "\n"
-    "assert(DEFINED CppStarter_INSTALL_DIR)\n"
-    "assert(EXISTS \"\${CppStarter_INSTALL_DIR}\")\n"
-    "\n"
-    "find_package(\n"
-    "  MyFibonacci REQUIRED\n"
-    "  HINTS \"\${CppStarter_INSTALL_DIR}\")\n"
-    "\n"
-    "add_executable(main main.cpp)\n"
-    "target_link_libraries(main my_fibonacci::sequence)\n"
-    "\n"
-    "add_custom_target(run_main ALL COMMAND \"$<TARGET_FILE:main>\")\n"
-    "add_dependencies(run_main main)\n")
+  cdeps_install_package(CppStarter github.com/threeal/cpp-starter main)
 
-  file(
-    WRITE project/main.cpp
-    "#include <my_fibonacci/sequence.hpp>\n"
-    "#include <iostream>\n"
-    "\n"
-    "int main() {\n"
-    "  const auto sequence = my_fibonacci::fibonacci_sequence(5);\n"
-    "  for (auto val : sequence) {\n"
-    "    std::cout << val << \" \";\n"
-    "  }\n"
-    "  std::cout << std::endl;\n"
-    "  return 0;\n"
-    "}\n")
-
-  assert_execute_process("${CMAKE_COMMAND}" -B project/build project)
-  assert_execute_process("${CMAKE_COMMAND}" --build project/build)
+  assert(DEFINED CppStarter_INSTALL_DIR)
+  assert(EXISTS "${CppStarter_INSTALL_DIR}")
 endsection()

--- a/test/PackageInstegration.cmake
+++ b/test/PackageInstegration.cmake
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.5)
+
+include(Assertion.cmake)
+
+section("it should generate the source code of the test project")
+  file(REMOVE_RECURSE project)
+  file(MAKE_DIRECTORY project)
+
+  file(
+    WRITE project/CMakeLists.txt
+    "cmake_minimum_required(VERSION 3.5)\n"
+    "project(Poject LANGUAGES CXX)\n"
+    "\n"
+    "find_package(MyFibonacci REQUIRED)\n")
+endsection()
+
+section("it should fail to configure the build due to missing dependencies")
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" -B project/build project
+    ERROR "Could not find a package configuration file provided by \"MyFibonacci\"")
+endsection()
+
+section("it should regenerate the source code of the test project")
+  file(
+    WRITE project/CMakeLists.txt
+    "cmake_minimum_required(VERSION 3.5)\n"
+    "project(Poject LANGUAGES CXX)\n"
+    "\n"
+    "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
+    "\n"
+    "cdeps_install_package(CppStarter github.com/threeal/cpp-starter main)\n"
+    "find_package(MyFibonacci REQUIRED HINTS \"\${CppStarter_INSTALL_DIR}\")\n"
+    "\n"
+    "add_executable(main main.cpp)\n"
+    "target_link_libraries(main my_fibonacci::sequence)\n"
+    "\n"
+    "add_custom_target(run COMMAND \"$<TARGET_FILE:main>\")\n"
+    "add_dependencies(run main)\n")
+
+  file(
+    WRITE project/main.cpp
+    "#include <my_fibonacci/sequence.hpp>\n"
+    "#include <iostream>\n"
+    "\n"
+    "int main() {\n"
+    "  const auto sequence = my_fibonacci::fibonacci_sequence(5);\n"
+    "  for (auto val : sequence) {\n"
+    "    std::cout << val << \" \";\n"
+    "  }\n"
+    "  std::cout << std::endl;\n"
+    "  return 0;\n"
+    "}\n")
+endsection()
+
+section("it should configure the build of the test project")
+  assert_execute_process("${CMAKE_COMMAND}" -B project/build project)
+endsection()
+
+section("it should build the test project")
+  assert_execute_process("${CMAKE_COMMAND}" --build project/build)
+endsection()
+
+section("it should run the test project")
+  assert_execute_process(
+    COMMAND "${CMAKE_COMMAND}" --build project/build --target run
+    OUTPUT "1 1 2 3 5")
+endsection()


### PR DESCRIPTION
This pull request resolves #103 by separating the package integration test from the package installation test into an independent `PackageIntegration.cmake` script.