### PR TITLE
Add Lock File For Package Directory

### DIFF
--- a/test/cdeps_build_package.cmake
+++ b/test/cdeps_build_package.cmake
@@ -3,28 +3,80 @@ find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
-section("it should fail to configure an external package build")
+section("it should fail to configure an invalid external package build")
   assert_fatal_error(
     CALL cdeps_build_package
-      ProjectStarter github.com/threeal/project-starter main
+      ProjectStarter github.com/threeal/project-starter v1.0.0
     MESSAGE "CDeps: Failed to configure ProjectStarter:")
 endsection()
 
-section("it should fail to build an external package")
+section("it should fail to build an external package with invalid options")
   assert_fatal_error(
-    CALL cdeps_build_package CppStarter github.com/threeal/cpp-starter main
+    CALL cdeps_build_package CppStarter github.com/threeal/cpp-starter v1.0.0
       OPTIONS CMAKE_CXX_FLAGS=invalid CMAKE_CXX_COMPILER_WORKS=ON
     MESSAGE "CDeps: Failed to build CppStarter:")
 endsection()
 
 section("it should build an external package")
-  cdeps_build_package(CppStarter github.com/threeal/cpp-starter main)
+  cdeps_build_package(CppStarter github.com/threeal/cpp-starter v1.0.0)
+
+  section("it should build in the correct path")
+    assert(DEFINED CppStarter_BUILD_DIR)
+    assert(EXISTS "${CppStarter_BUILD_DIR}")
+
+    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
+    assert(CppStarter_BUILD_DIR STREQUAL "${PACKAGE_DIR}/build")
+  endsection()
+
+  section("it should build the correct targets")
+    assert_execute_process(
+      COMMAND ${CppStarter_BUILD_DIR}/generate_sequence 5 OUTPUT "1 1 2 3 5")
+
+    assert(NOT EXISTS ${CppStarter_BUILD_DIR}/sequence_test)
+  endsection()
 endsection()
 
-section("it should build an external package in the correct path")
-  assert(DEFINED CppStarter_BUILD_DIR)
-  assert(EXISTS "${CppStarter_BUILD_DIR}")
+section("it should build an external package with a different options")
+  cdeps_build_package(
+    CppStarter github.com/threeal/cpp-starter v1.0.0 OPTIONS BUILD_TESTING=ON)
 
-  cdeps_get_package_dir(CppStarter PACKAGE_DIR)
-  assert(CppStarter_BUILD_DIR STREQUAL "${PACKAGE_DIR}/build")
+  section("it should build in the correct path")
+    assert(DEFINED CppStarter_BUILD_DIR)
+    assert(EXISTS "${CppStarter_BUILD_DIR}")
+
+    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
+    assert(CppStarter_BUILD_DIR STREQUAL "${PACKAGE_DIR}/build")
+  endsection()
+
+  section("it should build the correct targets")
+    assert_execute_process(
+      COMMAND ${CppStarter_BUILD_DIR}/generate_sequence 5 OUTPUT "1 1 2 3 5")
+
+    assert_execute_process(COMMAND ${CppStarter_BUILD_DIR}/sequence_test)
+  endsection()
+endsection()
+
+section("it should not rebuild an external package")
+  set(PREV_CMAKE_COMMAND "${CMAKE_COMMAND}")
+  set(CMAKE_COMMAND invalid)
+
+  cdeps_build_package(
+    CppStarter github.com/threeal/cpp-starter v1.0.0 OPTIONS BUILD_TESTING=ON)
+
+  set(CMAKE_COMMAND "${PREV_CMAKE_COMMAND}")
+
+  section("it should keep the correct path")
+    assert(DEFINED CppStarter_BUILD_DIR)
+    assert(EXISTS "${CppStarter_BUILD_DIR}")
+
+    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
+    assert(CppStarter_BUILD_DIR STREQUAL "${PACKAGE_DIR}/build")
+  endsection()
+
+  section("it should keep the build targets")
+    assert_execute_process(
+      COMMAND ${CppStarter_BUILD_DIR}/generate_sequence 5 OUTPUT "1 1 2 3 5")
+
+    assert_execute_process(COMMAND ${CppStarter_BUILD_DIR}/sequence_test)
+  endsection()
 endsection()

--- a/test/cdeps_download_package.cmake
+++ b/test/cdeps_download_package.cmake
@@ -3,20 +3,73 @@ find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
-section("it should fail to download the source code of an external package")
+section("it should fail to download an invalid external package")
   assert_fatal_error(
     CALL cdeps_download_package Google google.com main
     MESSAGE "CDeps: Failed to download Google:")
 endsection()
 
-section("it should download the source code of an external package")
-  cdeps_download_package(ProjectStarter github.com/threeal/project-starter main)
+section("it should download an external package")
+  cdeps_download_package(
+    ProjectStarter github.com/threeal/project-starter v1.0.0)
+
+  section("it should download to the correct path")
+    assert(DEFINED ProjectStarter_SOURCE_DIR)
+    assert(EXISTS "${ProjectStarter_SOURCE_DIR}")
+
+    cdeps_get_package_dir(ProjectStarter PACKAGE_DIR)
+    assert(ProjectStarter_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
+  endsection()
+
+  section("it should download the correct version")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
+      OUTPUT "5a80d2080c808f588856c3191512ea677eede6ee")
+  endsection()
 endsection()
 
-section("it should download the source code of an external package in the correct path")
-  assert(DEFINED ProjectStarter_SOURCE_DIR)
-  assert(EXISTS "${ProjectStarter_SOURCE_DIR}")
+section("it should download an external package with a different version")
+  cdeps_download_package(
+    ProjectStarter github.com/threeal/project-starter v1.1.0)
 
-  cdeps_get_package_dir(ProjectStarter PACKAGE_DIR)
-  assert(ProjectStarter_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
+  section("it should download to the correct path")
+    assert(DEFINED ProjectStarter_SOURCE_DIR)
+    assert(EXISTS "${ProjectStarter_SOURCE_DIR}")
+
+    cdeps_get_package_dir(ProjectStarter PACKAGE_DIR)
+    assert(ProjectStarter_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
+  endsection()
+
+  section("it should download the correct version")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
+      OUTPUT "316dec51ce6bfd7647d3e68d4cb2512a59a49682")
+  endsection()
+endsection()
+
+section("it should not redownload an external package")
+  set(PREV_GIT_EXECUTABLE "${GIT_EXECUTABLE}")
+  set(GIT_EXECUTABLE invalid)
+
+  cdeps_download_package(
+    ProjectStarter github.com/threeal/project-starter v1.1.0)
+
+  set(GIT_EXECUTABLE "${PREV_GIT_EXECUTABLE}")
+
+  section("it should keep the correct path")
+    assert(DEFINED ProjectStarter_SOURCE_DIR)
+    assert(EXISTS "${ProjectStarter_SOURCE_DIR}")
+
+    cdeps_get_package_dir(ProjectStarter PACKAGE_DIR)
+    assert(ProjectStarter_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
+  endsection()
+
+  section("it should keep the correct version")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
+      OUTPUT "316dec51ce6bfd7647d3e68d4cb2512a59a49682")
+  endsection()
 endsection()

--- a/test/cdeps_install_package.cmake
+++ b/test/cdeps_install_package.cmake
@@ -3,24 +3,50 @@ find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
-section("it should fail to install an external package")
+section("it should fail to install an external package with invalid options")
   assert_fatal_error(
-    CALL cdeps_install_package CppStarter github.com/threeal/cpp-starter main
+    CALL cdeps_install_package CppStarter github.com/threeal/cpp-starter v1.0.0
       OPTIONS CMAKE_SKIP_INSTALL_RULES=ON
     MESSAGE "CDeps: Failed to install CppStarter:")
 endsection()
 
 section("it should install an external package")
-  # TODO: Need to reset the CDeps directory.
-  file(REMOVE_RECURSE "${CDEPS_ROOT}")
+  cdeps_install_package(CppStarter github.com/threeal/cpp-starter v1.0.0)
 
-  cdeps_install_package(CppStarter github.com/threeal/cpp-starter main)
+  section("it should install to the correct path")
+    assert(DEFINED CppStarter_INSTALL_DIR)
+    assert(EXISTS "${CppStarter_INSTALL_DIR}")
+
+    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
+    assert(CppStarter_INSTALL_DIR STREQUAL "${PACKAGE_DIR}/install")
+  endsection()
+
+  section("it should install the correct targets")
+    assert_execute_process(
+      COMMAND ${CppStarter_INSTALL_DIR}/bin/generate_sequence 5
+      OUTPUT "1 1 2 3 5")
+  endsection()
 endsection()
 
-section("it should install an external package in the correct path")
-  assert(DEFINED CppStarter_INSTALL_DIR)
-  assert(EXISTS "${CppStarter_INSTALL_DIR}")
+section("it should not reinstall an external package")
+  set(PREV_CMAKE_COMMAND "${CMAKE_COMMAND}")
+  set(CMAKE_COMMAND invalid)
 
-  cdeps_get_package_dir(CppStarter PACKAGE_DIR)
-  assert(CppStarter_INSTALL_DIR STREQUAL "${PACKAGE_DIR}/install")
+  cdeps_install_package(CppStarter github.com/threeal/cpp-starter v1.0.0)
+
+  set(CMAKE_COMMAND "${PREV_CMAKE_COMMAND}")
+
+  section("it should keep the correct path")
+    assert(DEFINED CppStarter_INSTALL_DIR)
+    assert(EXISTS "${CppStarter_INSTALL_DIR}")
+
+    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
+    assert(CppStarter_INSTALL_DIR STREQUAL "${PACKAGE_DIR}/install")
+  endsection()
+
+  section("it should keep the install targets")
+    assert_execute_process(
+      COMMAND ${CppStarter_INSTALL_DIR}/bin/generate_sequence 5
+      OUTPUT "1 1 2 3 5")
+  endsection()
 endsection()


### PR DESCRIPTION
This pull request resolves #105 by modifying the `cdeps_download_package`, `cdeps_build_package`, and `cdeps_install_package` functions to check for the existence and validity of a lock file before attempting to download, build, or install a package. This allows the package source files, build outputs, and installation outputs to be reused across subsequent project configurations.