### PR TITLE
Bump Assertion.cmake to Version 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ if(CDEPS_ENABLE_TESTS)
   enable_testing()
 
   file(
-    DOWNLOAD https://raw.githubusercontent.com/threeal/assertion-cmake/511d7351ebedf65878b20acb1263095ba1c19b0a/cmake/Assertion.cmake
+    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
       ${CMAKE_BINARY_DIR}/Assertion.cmake
-    EXPECTED_MD5 3abb541f0d6d50d350a3591ff3cc0c27)
+    EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
 
   add_test(
     NAME "package directory retrieval"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,36 +20,16 @@ if(CDEPS_ENABLE_TESTS)
     DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
       ${CMAKE_BINARY_DIR}/Assertion.cmake
     EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+  include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
-  add_test(
-    NAME "package directory retrieval"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageDirRetrieval.cmake)
+  assertion_add_test(test/PackageDirRetrieval.cmake
+    NAME "package directory retrieval")
 
-  add_test(
-    NAME "package URL resolve"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageUrlResolve.cmake)
-
-  add_test(
-    NAME "package download"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageDownload.cmake)
-
-  add_test(
-    NAME "package build"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageBuild.cmake)
-
-  add_test(
-    NAME "package installation"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageInstallation.cmake)
-
-  add_test(
-    NAME "package integration"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/PackageInstegration.cmake)
+  assertion_add_test(test/PackageUrlResolve.cmake NAME "package URL resolve")
+  assertion_add_test(test/PackageDownload.cmake NAME "package download")
+  assertion_add_test(test/PackageBuild.cmake NAME "package build")
+  assertion_add_test(test/PackageInstallation.cmake NAME "package installation")
+  assertion_add_test(test/PackageInstegration.cmake NAME "package integration")
 endif()
 
 if(CDEPS_ENABLE_INSTALL)

--- a/test/PackageBuild.cmake
+++ b/test/PackageBuild.cmake
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
 find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-include(Assertion.cmake)
 
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")

--- a/test/PackageDirRetrieval.cmake
+++ b/test/PackageDirRetrieval.cmake
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
 find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-include(Assertion.cmake)
 
 set(CMAKE_SOURCE_DIR source-dir)
 

--- a/test/PackageDownload.cmake
+++ b/test/PackageDownload.cmake
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
 find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-include(Assertion.cmake)
 
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")

--- a/test/PackageInstallation.cmake
+++ b/test/PackageInstallation.cmake
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
 find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-include(Assertion.cmake)
 
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")

--- a/test/PackageInstegration.cmake
+++ b/test/PackageInstegration.cmake
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-include(Assertion.cmake)
-
 section("it should generate the source code of the test project")
   file(REMOVE_RECURSE project)
   file(MAKE_DIRECTORY project)

--- a/test/PackageUrlResolve.cmake
+++ b/test/PackageUrlResolve.cmake
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
 find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-include(Assertion.cmake)
 
 section("it should resolve a package URL that contains an HTTP protocol")
   cdeps_resolve_package_url(http://github.com/threeal/cpp-starter OUTPUT)


### PR DESCRIPTION
This pull request bumps the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [1.0.0](https://github.com/threeal/assertion-cmake/releases/tag/v1.0.0). It also updates the project to utilize the `assertion_add_test` function to declare a CMake test.