### PR TITLE
 Remove Unused Arguments Passed to Build Package Function

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -92,7 +92,7 @@ function(cdeps_build_package NAME URL REF)
   cmake_parse_arguments(PARSE_ARGV 2 ARG "" "" OPTIONS)
   cdeps_get_package_dir("${NAME}" PACKAGE_DIR)
 
-  cdeps_download_package("${NAME}" "${URL}" "${REF}" ${ARG_UNPARSED_ARGUMENTS})
+  cdeps_download_package("${NAME}" "${URL}" "${REF}")
 
   # Check if the build directory exists; if not, configure and build the package.
   if(NOT EXISTS ${PACKAGE_DIR}/build)


### PR DESCRIPTION
This pull request resolves #118 by removing the unparsed arguments that were being passed to the `cdeps_download_package` function from the `cdeps_build_package` function.