### PR TITLE
Fix Lock File Not Removed After Package Directory Removed

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -55,6 +55,9 @@ function(cdeps_download_package NAME URL REF)
       message(STATUS "CDeps: Using existing source directory for ${NAME}")
       set(${NAME}_SOURCE_DIR ${PACKAGE_DIR}/src PARENT_SCOPE)
       return()
+    else()
+      file(REMOVE ${PACKAGE_DIR}/src.lock)
+      file(REMOVE_RECURSE ${PACKAGE_DIR}/src)
     endif()
   endif()
 
@@ -69,7 +72,6 @@ function(cdeps_download_package NAME URL REF)
   cdeps_resolve_package_url("${URL}" GIT_URL)
 
   message(STATUS "CDeps: Downloading ${NAME} from ${GIT_URL} at ${REF}")
-  file(REMOVE_RECURSE ${PACKAGE_DIR}/src)
   execute_process(
     COMMAND "${GIT_EXECUTABLE}" clone -b "${REF}" "${GIT_URL}"
       ${PACKAGE_DIR}/src
@@ -109,13 +111,15 @@ function(cdeps_build_package NAME URL REF)
       message(STATUS "CDeps: Using existing build directory for ${NAME}")
       set(${NAME}_BUILD_DIR ${PACKAGE_DIR}/build PARENT_SCOPE)
       return()
+    else()
+      file(REMOVE ${PACKAGE_DIR}/build.lock)
+      file(REMOVE_RECURSE ${PACKAGE_DIR}/build)
     endif()
   endif()
 
   cdeps_download_package("${NAME}" "${URL}" "${REF}")
 
   message(STATUS "CDeps: Configuring ${NAME}")
-  file(REMOVE_RECURSE ${PACKAGE_DIR}/build)
   foreach(OPTION ${ARG_OPTIONS})
     list(APPEND CONFIGURE_ARGS -D "${OPTION}")
   endforeach()
@@ -175,13 +179,15 @@ function(cdeps_install_package NAME URL REF)
       message(STATUS "CDeps: Using existing install directory for ${NAME}")
       set(${NAME}_INSTALL_DIR ${PACKAGE_DIR}/install PARENT_SCOPE)
       return()
+    else()
+      file(REMOVE ${PACKAGE_DIR}/install.lock)
+      file(REMOVE_RECURSE ${PACKAGE_DIR}/install)
     endif()
   endif()
 
   cdeps_build_package("${NAME}" "${URL}" "${REF}" ${ARG_UNPARSED_ARGUMENTS})
 
   message(STATUS "CDeps: Installing ${NAME}")
-  file(REMOVE_RECURSE ${PACKAGE_DIR}/install)
   execute_process(
     COMMAND "${CMAKE_COMMAND}" --install "${${NAME}_BUILD_DIR}"
       --prefix ${PACKAGE_DIR}/install

--- a/test/cdeps_build_package.cmake
+++ b/test/cdeps_build_package.cmake
@@ -3,6 +3,49 @@ find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
+function(test_build_external_package)
+  section("it should build an external package")
+    cdeps_build_package(CppStarter github.com/threeal/cpp-starter v1.0.0)
+
+    section("it should build in the correct path")
+      assert(DEFINED CppStarter_BUILD_DIR)
+      assert(EXISTS "${CppStarter_BUILD_DIR}")
+
+      cdeps_get_package_dir(CppStarter PACKAGE_DIR)
+      assert(CppStarter_BUILD_DIR STREQUAL "${PACKAGE_DIR}/build")
+    endsection()
+
+    section("it should build the correct targets")
+      assert_execute_process(
+        COMMAND ${CppStarter_BUILD_DIR}/generate_sequence 5 OUTPUT "1 1 2 3 5")
+
+      assert(NOT EXISTS ${CppStarter_BUILD_DIR}/sequence_test)
+    endsection()
+  endsection()
+endfunction()
+
+test_build_external_package()
+
+section("it should rebuild an external package with a different options")
+  cdeps_build_package(
+    CppStarter github.com/threeal/cpp-starter v1.0.0 OPTIONS BUILD_TESTING=ON)
+
+  section("it should rebuild in the correct path")
+    assert(DEFINED CppStarter_BUILD_DIR)
+    assert(EXISTS "${CppStarter_BUILD_DIR}")
+
+    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
+    assert(CppStarter_BUILD_DIR STREQUAL "${PACKAGE_DIR}/build")
+  endsection()
+
+  section("it should rebuild the correct targets")
+    assert_execute_process(
+      COMMAND ${CppStarter_BUILD_DIR}/generate_sequence 5 OUTPUT "1 1 2 3 5")
+
+    assert_execute_process(COMMAND ${CppStarter_BUILD_DIR}/sequence_test)
+  endsection()
+endsection()
+
 section("it should fail to configure an invalid external package build")
   assert_fatal_error(
     CALL cdeps_build_package
@@ -17,51 +60,13 @@ section("it should fail to build an external package with invalid options")
     MESSAGE "CDeps: Failed to build CppStarter:")
 endsection()
 
-section("it should build an external package")
-  cdeps_build_package(CppStarter github.com/threeal/cpp-starter v1.0.0)
-
-  section("it should build in the correct path")
-    assert(DEFINED CppStarter_BUILD_DIR)
-    assert(EXISTS "${CppStarter_BUILD_DIR}")
-
-    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
-    assert(CppStarter_BUILD_DIR STREQUAL "${PACKAGE_DIR}/build")
-  endsection()
-
-  section("it should build the correct targets")
-    assert_execute_process(
-      COMMAND ${CppStarter_BUILD_DIR}/generate_sequence 5 OUTPUT "1 1 2 3 5")
-
-    assert(NOT EXISTS ${CppStarter_BUILD_DIR}/sequence_test)
-  endsection()
-endsection()
-
-section("it should build an external package with a different options")
-  cdeps_build_package(
-    CppStarter github.com/threeal/cpp-starter v1.0.0 OPTIONS BUILD_TESTING=ON)
-
-  section("it should build in the correct path")
-    assert(DEFINED CppStarter_BUILD_DIR)
-    assert(EXISTS "${CppStarter_BUILD_DIR}")
-
-    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
-    assert(CppStarter_BUILD_DIR STREQUAL "${PACKAGE_DIR}/build")
-  endsection()
-
-  section("it should build the correct targets")
-    assert_execute_process(
-      COMMAND ${CppStarter_BUILD_DIR}/generate_sequence 5 OUTPUT "1 1 2 3 5")
-
-    assert_execute_process(COMMAND ${CppStarter_BUILD_DIR}/sequence_test)
-  endsection()
-endsection()
+test_build_external_package()
 
 section("it should not rebuild an external package")
   set(PREV_CMAKE_COMMAND "${CMAKE_COMMAND}")
   set(CMAKE_COMMAND invalid)
 
-  cdeps_build_package(
-    CppStarter github.com/threeal/cpp-starter v1.0.0 OPTIONS BUILD_TESTING=ON)
+  cdeps_build_package(CppStarter github.com/threeal/cpp-starter v1.0.0)
 
   set(CMAKE_COMMAND "${PREV_CMAKE_COMMAND}")
 
@@ -77,6 +82,6 @@ section("it should not rebuild an external package")
     assert_execute_process(
       COMMAND ${CppStarter_BUILD_DIR}/generate_sequence 5 OUTPUT "1 1 2 3 5")
 
-    assert_execute_process(COMMAND ${CppStarter_BUILD_DIR}/sequence_test)
+    assert(NOT EXISTS ${CppStarter_BUILD_DIR}/sequence_test)
   endsection()
 endsection()

--- a/test/cdeps_download_package.cmake
+++ b/test/cdeps_download_package.cmake
@@ -3,37 +3,35 @@ find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
-section("it should fail to download an invalid external package")
-  assert_fatal_error(
-    CALL cdeps_download_package Google google.com main
-    MESSAGE "CDeps: Failed to download Google:")
-endsection()
+function(test_download_external_package)
+  section("it should download an external package")
+    cdeps_download_package(
+      ProjectStarter github.com/threeal/project-starter v1.0.0)
 
-section("it should download an external package")
-  cdeps_download_package(
-    ProjectStarter github.com/threeal/project-starter v1.0.0)
+    section("it should download to the correct path")
+      assert(DEFINED ProjectStarter_SOURCE_DIR)
+      assert(EXISTS "${ProjectStarter_SOURCE_DIR}")
 
-  section("it should download to the correct path")
-    assert(DEFINED ProjectStarter_SOURCE_DIR)
-    assert(EXISTS "${ProjectStarter_SOURCE_DIR}")
+      cdeps_get_package_dir(ProjectStarter PACKAGE_DIR)
+      assert(ProjectStarter_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
+    endsection()
 
-    cdeps_get_package_dir(ProjectStarter PACKAGE_DIR)
-    assert(ProjectStarter_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
+    section("it should download the correct version")
+      find_package(Git REQUIRED)
+      assert_execute_process(
+        COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
+        OUTPUT "5a80d2080c808f588856c3191512ea677eede6ee")
+    endsection()
   endsection()
+endfunction()
 
-  section("it should download the correct version")
-    find_package(Git REQUIRED)
-    assert_execute_process(
-      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
-      OUTPUT "5a80d2080c808f588856c3191512ea677eede6ee")
-  endsection()
-endsection()
+test_download_external_package()
 
-section("it should download an external package with a different version")
+section("it should redownload an external package with a different version")
   cdeps_download_package(
     ProjectStarter github.com/threeal/project-starter v1.1.0)
 
-  section("it should download to the correct path")
+  section("it should redownload to the correct path")
     assert(DEFINED ProjectStarter_SOURCE_DIR)
     assert(EXISTS "${ProjectStarter_SOURCE_DIR}")
 
@@ -41,7 +39,7 @@ section("it should download an external package with a different version")
     assert(ProjectStarter_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
   endsection()
 
-  section("it should download the correct version")
+  section("it should redownload the correct version")
     find_package(Git REQUIRED)
     assert_execute_process(
       COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
@@ -49,12 +47,20 @@ section("it should download an external package with a different version")
   endsection()
 endsection()
 
+section("it should fail to download an invalid external package")
+  assert_fatal_error(
+    CALL cdeps_download_package Google google.com main
+    MESSAGE "CDeps: Failed to download Google:")
+endsection()
+
+test_download_external_package()
+
 section("it should not redownload an external package")
   set(PREV_GIT_EXECUTABLE "${GIT_EXECUTABLE}")
   set(GIT_EXECUTABLE invalid)
 
   cdeps_download_package(
-    ProjectStarter github.com/threeal/project-starter v1.1.0)
+    ProjectStarter github.com/threeal/project-starter v1.0.0)
 
   set(GIT_EXECUTABLE "${PREV_GIT_EXECUTABLE}")
 
@@ -70,6 +76,6 @@ section("it should not redownload an external package")
     find_package(Git REQUIRED)
     assert_execute_process(
       COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
-      OUTPUT "316dec51ce6bfd7647d3e68d4cb2512a59a49682")
+      OUTPUT "5a80d2080c808f588856c3191512ea677eede6ee")
   endsection()
 endsection()

--- a/test/cdeps_install_package.cmake
+++ b/test/cdeps_install_package.cmake
@@ -3,6 +3,28 @@ find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")
 
+function(test_install_external_package)
+  section("it should install an external package")
+    cdeps_install_package(CppStarter github.com/threeal/cpp-starter v1.0.0)
+
+    section("it should install to the correct path")
+      assert(DEFINED CppStarter_INSTALL_DIR)
+      assert(EXISTS "${CppStarter_INSTALL_DIR}")
+
+      cdeps_get_package_dir(CppStarter PACKAGE_DIR)
+      assert(CppStarter_INSTALL_DIR STREQUAL "${PACKAGE_DIR}/install")
+    endsection()
+
+    section("it should install the correct targets")
+      assert_execute_process(
+        COMMAND ${CppStarter_INSTALL_DIR}/bin/generate_sequence 5
+        OUTPUT "1 1 2 3 5")
+    endsection()
+  endsection()
+endfunction()
+
+test_install_external_package()
+
 section("it should fail to install an external package with invalid options")
   assert_fatal_error(
     CALL cdeps_install_package CppStarter github.com/threeal/cpp-starter v1.0.0
@@ -10,23 +32,7 @@ section("it should fail to install an external package with invalid options")
     MESSAGE "CDeps: Failed to install CppStarter:")
 endsection()
 
-section("it should install an external package")
-  cdeps_install_package(CppStarter github.com/threeal/cpp-starter v1.0.0)
-
-  section("it should install to the correct path")
-    assert(DEFINED CppStarter_INSTALL_DIR)
-    assert(EXISTS "${CppStarter_INSTALL_DIR}")
-
-    cdeps_get_package_dir(CppStarter PACKAGE_DIR)
-    assert(CppStarter_INSTALL_DIR STREQUAL "${PACKAGE_DIR}/install")
-  endsection()
-
-  section("it should install the correct targets")
-    assert_execute_process(
-      COMMAND ${CppStarter_INSTALL_DIR}/bin/generate_sequence 5
-      OUTPUT "1 1 2 3 5")
-  endsection()
-endsection()
+test_install_external_package()
 
 section("it should not reinstall an external package")
   set(PREV_CMAKE_COMMAND "${CMAKE_COMMAND}")


### PR DESCRIPTION
This pull request resolves #124 by modifying the `cdeps_download_package`, `cdeps_build_package`, and `cdeps_install_package` functions to remove the corresponding lock file when the package directory is removed. This change also updates the tests to handle cases where downloading, building, and installing a package are retried after a failure.