### PR TITLE
Modify Package Functions to Avoid Determining Directories from Variables

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -198,7 +198,7 @@ function(cdeps_install_package NAME)
 
   message(STATUS "CDeps: Installing ${NAME}")
   execute_process(
-    COMMAND "${CMAKE_COMMAND}" --install "${${NAME}_BUILD_DIR}"
+    COMMAND "${CMAKE_COMMAND}" --install ${PACKAGE_DIR}/build
       --prefix ${PACKAGE_DIR}/install
     ERROR_VARIABLE ERR
     RESULT_VARIABLE RES

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -135,7 +135,7 @@ function(cdeps_build_package NAME)
   endforeach()
   execute_process(
     COMMAND "${CMAKE_COMMAND}" -B ${PACKAGE_DIR}/build ${CONFIGURE_ARGS}
-      "${${NAME}_SOURCE_DIR}"
+      ${PACKAGE_DIR}/src
     ERROR_VARIABLE ERR
     RESULT_VARIABLE RES
     OUTPUT_QUIET

--- a/test/cdeps_build_package.cmake
+++ b/test/cdeps_build_package.cmake
@@ -12,7 +12,7 @@ section(
     MESSAGE "CDeps: Sample must be downloaded before building")
 endsection()
 
-macro(test_generate_and_build_external_package)
+function(test_generate_and_build_external_package)
   section("it should generate external package source files")
     file(
       WRITE ${SAMPLE_PACKAGE_DIR}/src/CMakeLists.txt
@@ -48,8 +48,6 @@ macro(test_generate_and_build_external_package)
     file(
       WRITE ${SAMPLE_PACKAGE_DIR}/src.lock
       "Sample github.com/user/sample main")
-
-    set(Sample_SOURCE_DIR ${SAMPLE_PACKAGE_DIR}/src)
   endsection()
 
   section("it should build an external package")
@@ -69,7 +67,7 @@ macro(test_generate_and_build_external_package)
       assert(NOT EXISTS ${SAMPLE_PACKAGE_DIR}/build/mars)
     endsection()
   endsection()
-endmacro()
+endfunction()
 
 test_generate_and_build_external_package()
 

--- a/test/cdeps_install_package.cmake
+++ b/test/cdeps_install_package.cmake
@@ -50,7 +50,7 @@ section("it should fail to install an external package that has not been built")
     MESSAGE "CDeps: Sample must be built before installation")
 endsection()
 
-macro(test_build_and_install_external_package)
+function(test_build_and_install_external_package)
   section("it should build an external package")
     cdeps_build_package(Sample)
   endsection()
@@ -75,7 +75,7 @@ macro(test_build_and_install_external_package)
       assert(NOT EXISTS ${Sample_INSTALL_DIR}/bin/mars)
     endsection()
   endsection()
-endmacro()
+endfunction()
 
 test_build_and_install_external_package()
 


### PR DESCRIPTION
This pull request resolves #128 by preventing the `cdeps_build_package` function from determining the source directory based on the `${NAME}_SOURCE_DIR` variable and the `cdeps_install_package` function from determining the build directory based on the `${NAME}_BUILD_DIR` variable. It also updates the tests accordingly.