### PR TITLE
Add Support to Download External Package Submodules Recursively

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -37,18 +37,25 @@ endfunction()
 
 # Downloads the source files of an external package.
 #
-# cdeps_download_package(<name> <url> <ref>)
+# cdeps_download_package(<name> <url> <ref> [RECURSE_SUBMODULES])
 #
 # This function downloads the source files of an external package named `<name>`
 # using Git. It downloads the source files from the specified `<url>` with a
 # particular `<ref>`. The `<ref>` can be a branch, tag, or commit hash.
 #
+# If the `RECURSE_SUBMODULES` option is specified, the external package will be
+# downloaded along with its submodules recursively.
+#
 # This function outputs the `<name>_SOURCE_DIR` variable, which contains the
 # path to the downloaded source files of the external package.
 function(cdeps_download_package NAME URL REF)
+  cmake_parse_arguments(PARSE_ARGV 3 ARG RECURSE_SUBMODULES "" "")
   cdeps_get_package_dir("${NAME}" PACKAGE_DIR)
 
   set(SOURCE_LOCK "${NAME} ${URL} ${REF}")
+  if(ARG_RECURSE_SUBMODULES)
+    string(APPEND SOURCE_LOCK " RECURSE_SUBMODULES")
+  endif()
 
   # Check if the lock file is valid; redownload the source files if it isn't.
   if(EXISTS ${PACKAGE_DIR}/src.lock)
@@ -73,9 +80,14 @@ function(cdeps_download_package NAME URL REF)
 
   cdeps_resolve_package_url("${URL}" GIT_URL)
 
+  set(CLONE_OPTS -b "${REF}" --depth 1)
+  if(ARG_RECURSE_SUBMODULES)
+    list(APPEND CLONE_OPTS --recurse-submodules)
+  endif()
+
   message(STATUS "CDeps: Downloading ${NAME} from ${GIT_URL} at ${REF}")
   execute_process(
-    COMMAND "${GIT_EXECUTABLE}" clone -b "${REF}" --depth 1 "${GIT_URL}"
+    COMMAND "${GIT_EXECUTABLE}" clone ${CLONE_OPTS} "${GIT_URL}"
       ${PACKAGE_DIR}/src
     ERROR_VARIABLE ERR
     RESULT_VARIABLE RES

--- a/test/cdeps_download_package.cmake
+++ b/test/cdeps_download_package.cmake
@@ -102,3 +102,74 @@ section("it should not redownload an external package")
       OUTPUT "1")
   endsection()
 endsection()
+
+section("it should download an external package without submodules")
+  cdeps_download_package(
+    GitSubmoduleExample github.com/threeal/git-submodule-example v1.0.0)
+
+  section("it should download to the correct path")
+    assert(DEFINED GitSubmoduleExample_SOURCE_DIR)
+    assert(EXISTS "${GitSubmoduleExample_SOURCE_DIR}")
+
+    cdeps_get_package_dir(GitSubmoduleExample PACKAGE_DIR)
+    assert(GitSubmoduleExample_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
+  endsection()
+
+  section("it should download the correct version")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
+      OUTPUT "9264df25ee6d43751d8948b746e808cf6069f834")
+  endsection()
+
+  section("it should download only the latest change")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-list --count HEAD
+      OUTPUT "1")
+  endsection()
+
+  section("it should not download the submodules")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" submodule status
+        --recursive
+      OUTPUT "-bea29a84b6c55a49fef34be3e7a17498c633b6d9 project-starter")
+  endsection()
+endsection()
+
+section("it should redownload an external package with submodules")
+  cdeps_download_package(
+    GitSubmoduleExample github.com/threeal/git-submodule-example v1.0.0
+    RECURSE_SUBMODULES)
+
+  section("it should redownload to the correct path")
+    assert(DEFINED GitSubmoduleExample_SOURCE_DIR)
+    assert(EXISTS "${GitSubmoduleExample_SOURCE_DIR}")
+
+    cdeps_get_package_dir(GitSubmoduleExample PACKAGE_DIR)
+    assert(GitSubmoduleExample_SOURCE_DIR STREQUAL "${PACKAGE_DIR}/src")
+  endsection()
+
+  section("it should redownload the correct version")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-parse HEAD
+      OUTPUT "9264df25ee6d43751d8948b746e808cf6069f834")
+  endsection()
+
+  section("it should redownload only the latest change")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" rev-list --count HEAD
+      OUTPUT "1")
+  endsection()
+
+  section("it should redownload the submodules")
+    find_package(Git REQUIRED)
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C "${PACKAGE_DIR}/src" submodule status
+        --recursive
+      OUTPUT "bea29a84b6c55a49fef34be3e7a17498c633b6d9 project-starter \\(v1\\.2\\.0\\)")
+  endsection()
+endsection()


### PR DESCRIPTION
This pull request resolves #138 by adding a new `RECURSE_SUBMODULES` option to the `cdeps_download_package` function, which allows an external package to be downloaded along with its submodules.