### PR TITLE
Build External Package Using Main Build System Generator by Default

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -132,7 +132,8 @@ endfunction()
 #
 # If the `GENERATOR` option is specified, the package will be built using the
 # `<generator>` build system generator. Otherwise, it will be built using the
-# default build system generator, which is platform-specific.
+# same build system generator as the main project, specified by the
+# `CMAKE_GENERATOR` variable.
 #
 # If the `OPTIONS` option is specified, an additional variable specified in each
 # `<options>...` will be defined for building the package. The `<options>...`
@@ -143,6 +144,10 @@ endfunction()
 # to the built external package.
 function(cdeps_build_package NAME)
   cmake_parse_arguments(PARSE_ARGV 1 ARG "" GENERATOR OPTIONS)
+
+  if(NOT DEFINED ARG_GENERATOR AND DEFINED CMAKE_GENERATOR)
+    set(ARG_GENERATOR "${CMAKE_GENERATOR}")
+  endif()
 
   cdeps_get_package_dir("${NAME}" PACKAGE_DIR)
   if(NOT EXISTS ${PACKAGE_DIR}/src.lock)

--- a/test/cdeps_build_package.cmake
+++ b/test/cdeps_build_package.cmake
@@ -75,8 +75,14 @@ endfunction()
 
 test_generate_and_build_external_package()
 
-section("it should rebuild an external package with a different options")
-  cdeps_build_package(Sample GENERATOR Ninja OPTIONS BUILD_MARS=ON)
+section("it should rebuild an external package with the same generator as the"
+  " parent project")
+
+  set(CMAKE_GENERATOR Ninja)
+
+  cdeps_build_package(Sample)
+
+  unset(CMAKE_GENERATOR)
 
   section("it should rebuild in the correct path")
     assert(DEFINED Sample_BUILD_DIR)
@@ -93,8 +99,52 @@ section("it should rebuild an external package with a different options")
     assert(EXISTS ${SAMPLE_PACKAGE_DIR}/build/earth)
     assert_execute_process(COMMAND ${SAMPLE_PACKAGE_DIR}/build/earth)
 
+    assert(NOT EXISTS ${SAMPLE_PACKAGE_DIR}/build/mars)
+  endsection()
+endsection()
+
+section("it should rebuild an external package with a different options")
+  cdeps_build_package(Sample OPTIONS BUILD_MARS=ON)
+
+  section("it should rebuild in the correct path")
+    assert(DEFINED Sample_BUILD_DIR)
+    assert(EXISTS "${Sample_BUILD_DIR}")
+
+    assert(Sample_BUILD_DIR STREQUAL ${SAMPLE_PACKAGE_DIR}/build)
+  endsection()
+
+  section("it should use the correct build system generator")
+    assert(NOT EXISTS ${Sample_BUILD_DIR}/build.ninja)
+  endsection()
+
+  section("it should rebuild the correct targets")
+    assert(EXISTS ${SAMPLE_PACKAGE_DIR}/build/earth)
+    assert_execute_process(COMMAND ${SAMPLE_PACKAGE_DIR}/build/earth)
+
     assert(EXISTS ${SAMPLE_PACKAGE_DIR}/build/mars)
     assert_execute_process(COMMAND ${SAMPLE_PACKAGE_DIR}/build/mars)
+  endsection()
+endsection()
+
+section("it should rebuild an external package with a different generator")
+  cdeps_build_package(Sample GENERATOR Ninja)
+
+  section("it should rebuild in the correct path")
+    assert(DEFINED Sample_BUILD_DIR)
+    assert(EXISTS "${Sample_BUILD_DIR}")
+
+    assert(Sample_BUILD_DIR STREQUAL ${SAMPLE_PACKAGE_DIR}/build)
+  endsection()
+
+  section("it should use the correct build system generator")
+    assert(EXISTS ${Sample_BUILD_DIR}/build.ninja)
+  endsection()
+
+  section("it should rebuild the correct targets")
+    assert(EXISTS ${SAMPLE_PACKAGE_DIR}/build/earth)
+    assert_execute_process(COMMAND ${SAMPLE_PACKAGE_DIR}/build/earth)
+
+    assert(NOT EXISTS ${SAMPLE_PACKAGE_DIR}/build/mars)
   endsection()
 endsection()
 


### PR DESCRIPTION
This pull request modifies the `cdeps_build_package` function to use the main project's build system generator by default when building external packages. This change also updates the tests accordingly.