### PR TITLE
Add Module Version Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project(
   CDeps
-  VERSION 0.0.0
+  VERSION 0.1.0
   DESCRIPTION "Build and install missing dependencies in your CMake project"
   HOMEPAGE_URL https://github.com/threeal/CDeps.cmake
   LANGUAGES NONE)

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 # This variable contains the version of the included `CDeps.cmake` module.
-set(CDEPS_VERSION 0.0.0)
+set(CDEPS_VERSION 0.1.0)
 
 # Retrieves the path of a package directory.
 #

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -20,6 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# This variable contains the version of the included `CDeps.cmake` module.
+set(CDEPS_VERSION 0.0.0)
+
 # Retrieves the path of a package directory.
 #
 # cdeps_get_package_dir(<name> <output_dir>)


### PR DESCRIPTION
This pull request resolves #144 by adding a new `CDEPS_VERSION` variable that contains the version of the included `CDeps.cmake` module. It also bumps the project version to 0.1.0.