### PR TITLE
Follow CMake Starter Version 2.0.0 Style and Configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Build Project
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
+      - name: Checkout Project
         uses: actions/checkout@v4.2.0
 
       - name: Configure Project
@@ -20,7 +20,7 @@ jobs:
       - name: Install Project
         run: cmake --install build --prefix install
 
-      - name: Upload Project as Artifact
+      - name: Upload Project
         uses: actions/upload-artifact@v4.4.0
         with:
           path: install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,4 +23,7 @@ jobs:
       - name: Upload Project
         uses: actions/upload-artifact@v4.4.0
         with:
+          name: CDeps
           path: install
+          if-no-files-found: error
+          overwrite: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Ninja
         run: sudo apt-get install -y ninja-build
 
-      - name: Checkout
+      - name: Checkout Project
         uses: actions/checkout@v4.2.0
 
       - name: Configure Project

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,3 +23,5 @@ jobs:
 
       - name: Test Project
         uses: threeal/ctest-action@v1.1.0
+        with:
+          verbose: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,17 +11,19 @@ project(
 option(CDEPS_ENABLE_TESTS "Enable test targets.")
 option(CDEPS_ENABLE_INSTALL "Enable install targets." ${PROJECT_IS_TOP_LEVEL})
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+# Prefer system packages over the find modules provided by this project.
+if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+endif()
+
 include(cmake/CDeps.cmake)
 
 if(CDEPS_ENABLE_TESTS)
   enable_testing()
 
-  file(
-    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
-      ${CMAKE_BINARY_DIR}/Assertion.cmake
-    EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
-  include(${CMAKE_BINARY_DIR}/Assertion.cmake)
-
+  find_package(Assertion 1.0.0 REQUIRED)
   assertion_add_test(test/cdeps_build_package.cmake)
   assertion_add_test(test/cdeps_download_package.cmake)
   assertion_add_test(test/cdeps_get_package_dir.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,7 @@ project(
   VERSION 0.0.0
   DESCRIPTION "Build and install missing dependencies in your CMake project"
   HOMEPAGE_URL https://github.com/threeal/CDeps.cmake
-  LANGUAGES NONE
-)
+  LANGUAGES NONE)
 
 option(CDEPS_ENABLE_TESTS "Enable test targets.")
 option(CDEPS_ENABLE_INSTALL "Enable install targets." ${PROJECT_IS_TOP_LEVEL})
@@ -34,16 +33,12 @@ endif()
 
 if(CDEPS_ENABLE_INSTALL)
   include(CMakePackageConfigHelpers)
-  write_basic_package_version_file(
-    cmake/CDepsConfigVersion.cmake
-    COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT
-  )
+  write_basic_package_version_file(cmake/CDepsConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
 
   install(
-    FILES
-      cmake/CDeps.cmake
+    FILES cmake/CDeps.cmake
       cmake/CDepsConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/CDepsConfigVersion.cmake
-    DESTINATION lib/cmake/CDeps
-  )
+    DESTINATION lib/cmake/CDeps)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 if(CDEPS_ENABLE_INSTALL)
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
-    CDepsConfigVersion.cmake
+    cmake/CDepsConfigVersion.cmake
     COMPATIBILITY SameMajorVersion
   )
 
@@ -43,7 +43,7 @@ if(CDEPS_ENABLE_INSTALL)
     FILES
       cmake/CDeps.cmake
       cmake/CDepsConfig.cmake
-      ${CMAKE_CURRENT_BINARY_DIR}/CDepsConfigVersion.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/CDepsConfigVersion.cmake
     DESTINATION lib/cmake/CDeps
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CDEPS_ENABLE_INSTALL)
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     cmake/CDepsConfigVersion.cmake
-    COMPATIBILITY SameMajorVersion
+    COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT
   )
 
   install(

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-include_guard(GLOBAL)
-
 # Retrieves the path of a package directory.
 #
 # cdeps_get_package_dir(<name> <output_dir>)

--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -108,8 +108,7 @@ function(cdeps_download_package NAME URL REF)
       ${PACKAGE_DIR}/src
     ERROR_VARIABLE ERR
     RESULT_VARIABLE RES
-    OUTPUT_QUIET
-  )
+    OUTPUT_QUIET)
   if(NOT "${RES}" EQUAL 0)
     file(REMOVE_RECURSE ${PACKAGE_DIR}/src)
     message(FATAL_ERROR "CDeps: Failed to download ${NAME}: ${ERR}")
@@ -187,8 +186,7 @@ function(cdeps_build_package NAME)
       ${PACKAGE_DIR}/src
     ERROR_VARIABLE ERR
     RESULT_VARIABLE RES
-    OUTPUT_QUIET
-  )
+    OUTPUT_QUIET)
   if(NOT "${RES}" EQUAL 0)
     file(REMOVE_RECURSE ${PACKAGE_DIR}/build)
     message(FATAL_ERROR "CDeps: Failed to configure ${NAME}: ${ERR}")
@@ -200,8 +198,7 @@ function(cdeps_build_package NAME)
     COMMAND "${CMAKE_COMMAND}" --build ${PACKAGE_DIR}/build
     ERROR_VARIABLE ERR
     RESULT_VARIABLE RES
-    OUTPUT_QUIET
-  )
+    OUTPUT_QUIET)
   if(NOT "${RES}" EQUAL 0)
     file(REMOVE_RECURSE ${PACKAGE_DIR}/build)
     message(FATAL_ERROR "CDeps: Failed to build ${NAME}: ${ERR}")
@@ -251,8 +248,7 @@ function(cdeps_install_package NAME)
       --prefix ${PACKAGE_DIR}/install
     ERROR_VARIABLE ERR
     RESULT_VARIABLE RES
-    OUTPUT_QUIET
-  )
+    OUTPUT_QUIET)
   if(NOT "${RES}" EQUAL 0)
     file(REMOVE_RECURSE ${PACKAGE_DIR}/install)
     message(FATAL_ERROR "CDeps: Failed to install ${NAME}: ${ERR}")

--- a/cmake/FindAssertion.cmake
+++ b/cmake/FindAssertion.cmake
@@ -1,0 +1,8 @@
+file(
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
+    ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
+  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Assertion REQUIRED_VARS ASSERTION_LIST_FILE)

--- a/test/cdeps_build_package.cmake
+++ b/test/cdeps_build_package.cmake
@@ -1,4 +1,4 @@
-find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CDeps.cmake)
 
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")

--- a/test/cdeps_download_package.cmake
+++ b/test/cdeps_download_package.cmake
@@ -1,4 +1,4 @@
-find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CDeps.cmake)
 
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")

--- a/test/cdeps_get_package_dir.cmake
+++ b/test/cdeps_get_package_dir.cmake
@@ -1,4 +1,4 @@
-find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CDeps.cmake)
 
 set(CMAKE_SOURCE_DIR source-dir)
 

--- a/test/cdeps_install_package.cmake
+++ b/test/cdeps_install_package.cmake
@@ -1,4 +1,4 @@
-find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CDeps.cmake)
 
 set(CDEPS_ROOT ${CMAKE_CURRENT_BINARY_DIR}/.cdeps)
 file(REMOVE_RECURSE "${CDEPS_ROOT}")

--- a/test/cdeps_resolve_package_url.cmake
+++ b/test/cdeps_resolve_package_url.cmake
@@ -1,4 +1,4 @@
-find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CDeps.cmake)
 
 section("it should resolve a package URL that contains an HTTP protocol")
   cdeps_resolve_package_url(http://github.com/threeal/cpp-starter OUTPUT)

--- a/test/integration.cmake
+++ b/test/integration.cmake
@@ -22,7 +22,7 @@ section("it should regenerate the source code of the test project")
     "cmake_minimum_required(VERSION 3.5)\n"
     "project(Poject LANGUAGES CXX)\n"
     "\n"
-    "find_package(CDeps REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)\n"
+    "include(${CMAKE_CURRENT_LIST_DIR}/../cmake/CDeps.cmake)\n"
     "\n"
     "cdeps_download_package(CppStarter github.com/threeal/cpp-starter main)\n"
     "cdeps_build_package(CppStarter)\n"


### PR DESCRIPTION
This pull request resolves #146 by updating the project to follow the style and configuration of [CMake Starter version 2.0.0](https://github.com/threeal/cmake-starter/tree/v2.0.0). Refer to each commit for more details about the changes.