### PR TITLE
Add Support for Downloading Package Using Commit Hash as the Reference

### DIFF
--- a/test/test_download_version.cmake
+++ b/test/test_download_version.cmake
@@ -36,4 +36,20 @@ section("it should redownload the package with a specific tag name")
   endsection()
 endsection()
 
+section("it should redownload the package with a specific commit hash")
+  cdeps_download_package(pkg github.com/threeal/project-starter
+    ad2c03959cb67fffc7cce7266bc244c73a2af8ec)
+
+  section("it should regenerate the lock file")
+    file(READ .cdeps/pkg/src.lock CONTENT)
+    assert(CONTENT MATCHES ad2c03959cb67fffc7cce7266bc244c73a2af8ec$)
+  endsection()
+
+  section("it should redownload with the correct commit hash")
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C .cdeps/pkg/src rev-parse HEAD
+      OUTPUT ad2c03959cb67fffc7cce7266bc244c73a2af8ec)
+  endsection()
+endsection()
+
 file(REMOVE_RECURSE .cdeps)

--- a/test/test_download_version.cmake
+++ b/test/test_download_version.cmake
@@ -5,35 +5,34 @@ find_package(Git REQUIRED QUIET)
 set(CDEPS_DIR .cdeps)
 file(REMOVE_RECURSE .cdeps)
 
-section("it should download a package with a specific version")
-  cdeps_download_package(pkg github.com/threeal/project-starter v1.0.0)
+section("it should download a package with a specific branch name")
+  cdeps_download_package(pkg github.com/threeal/project-starter main)
 
   section("it should generate the lock file")
+    file(READ .cdeps/pkg/src.lock CONTENT)
+    assert(CONTENT MATCHES main$)
+  endsection()
+
+  section("it should download with the correct branch name")
+    assert_execute_process(
+      COMMAND ${GIT_EXECUTABLE} -C .cdeps/pkg/src rev-parse --abbrev-ref HEAD
+      OUTPUT main)
+  endsection()
+endsection()
+
+section("it should redownload the package with a specific tag name")
+  cdeps_download_package(pkg github.com/threeal/project-starter v1.0.0)
+
+  section("it should regenerate the lock file")
     file(READ .cdeps/pkg/src.lock CONTENT)
     assert(CONTENT MATCHES v1.0.0$)
   endsection()
 
-  section("it should download with the correct version")
+  section("it should redownload with the correct tag name")
     assert_execute_process(
       COMMAND ${GIT_EXECUTABLE} -C .cdeps/pkg/src
         describe --exact-match --tags v1.0.0
       OUTPUT v1.0.0)
-  endsection()
-endsection()
-
-section("it should redownload the package with a different version")
-  cdeps_download_package(pkg github.com/threeal/project-starter v1.1.0)
-
-  section("it should regenerate the lock file")
-    file(READ .cdeps/pkg/src.lock CONTENT)
-    assert(CONTENT MATCHES v1.1.0$)
-  endsection()
-
-  section("it should redownload with the correct version")
-    assert_execute_process(
-      COMMAND ${GIT_EXECUTABLE} -C .cdeps/pkg/src
-        describe --exact-match --tags v1.1.0
-      OUTPUT v1.1.0)
   endsection()
 endsection()
 


### PR DESCRIPTION
This pull request resolves #169 by modifying the commands executed in the `cdeps_download_package` function to allow external packages to be downloaded using a commit hash as the reference. It also updates the tests in the `test_download_version.cmake` file to ensure the function can download packages using a branch name, tag name, or commit hash as the reference.