### PR TITLE
Initialize Empty Repository Instead to Download Packages

### DIFF
--- a/cmake/CDeps.cmake
+++ b/cmake/CDeps.cmake
@@ -65,6 +65,7 @@ function(cdeps_download_package NAME URL REF)
 
   message(STATUS "CDeps: Downloading ${NAME}")
   file(REMOVE_RECURSE ${CDEPS_DIR}/${NAME}/src)
+  file(MAKE_DIRECTORY ${CDEPS_DIR}/${NAME}/src)
 
   if(NOT DEFINED GIT_EXECUTABLE)
     find_package(Git)
@@ -74,8 +75,10 @@ function(cdeps_download_package NAME URL REF)
     endif()
   endif()
 
-  set(CLONE_COMMAND "${GIT_EXECUTABLE}" clone --no-checkout --depth 1
-    https://${URL}.git ${CDEPS_DIR}/${NAME}/src)
+  set(INIT_COMMAND "${GIT_EXECUTABLE}" -C ${CDEPS_DIR}/${NAME}/src init)
+
+  set(ADD_REMOTE_COMMAND "${GIT_EXECUTABLE}" -C ${CDEPS_DIR}/${NAME}/src
+    remote add origin https://${URL}.git)
 
   set(FETCH_COMMAND "${GIT_EXECUTABLE}" -C ${CDEPS_DIR}/${NAME}/src
     fetch --depth 1 --tags origin "${REF}")
@@ -83,7 +86,8 @@ function(cdeps_download_package NAME URL REF)
   set(CHECKOUT_COMMAND "${GIT_EXECUTABLE}" -C ${CDEPS_DIR}/${NAME}/src
     checkout "${REF}")
 
-  set(COMMANDS CLONE_COMMAND FETCH_COMMAND CHECKOUT_COMMAND)
+  set(COMMANDS INIT_COMMAND ADD_REMOTE_COMMAND FETCH_COMMAND
+    CHECKOUT_COMMAND)
 
   if(ARG_RECURSE_SUBMODULES)
     set(SUBMODULE_COMMAND "${GIT_EXECUTABLE}" -C ${CDEPS_DIR}/${NAME}/src

--- a/test/test_download.cmake
+++ b/test/test_download.cmake
@@ -71,8 +71,8 @@ section("it should fail to redownload the package because of an invalid URL")
     assert(NOT EXISTS .cdeps/pkg/src.lock)
   endsection()
 
-  section("it should remove the source directory")
-    assert(NOT EXISTS .cdeps/pkg/src)
+  section("it should not remove the source directory")
+    assert(EXISTS .cdeps/pkg/src)
   endsection()
 endsection()
 


### PR DESCRIPTION
This pull request resolves #177 by modifying the commands for downloading packages in the `cdeps_download_package` function. Instead of cloning from a remote repository, the function will initialize an empty repository and fetch the specified reference, ensuring that only the specified reference of the package is downloaded and stored.