### PR TITLE
Generate Package Config File During Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,16 @@ if(CDEPS_ENABLE_TESTS)
 endif()
 
 if(CDEPS_ENABLE_INSTALL)
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake/CDepsConfig.cmake
+    "include(\${CMAKE_CURRENT_LIST_DIR}/CDeps.cmake)\n")
+
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(cmake/CDepsConfigVersion.cmake
     COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
 
   install(
     FILES cmake/CDeps.cmake
-      cmake/CDepsConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/CDepsConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/CDepsConfigVersion.cmake
     DESTINATION lib/cmake/CDeps)
 endif()

--- a/cmake/CDepsConfig.cmake
+++ b/cmake/CDepsConfig.cmake
@@ -1,1 +1,0 @@
-include(${CMAKE_CURRENT_LIST_DIR}/CDeps.cmake)


### PR DESCRIPTION
This pull request resolves #179 by modifying the `CDepsConfig.cmake` file to be generated during the build process instead of being committed to the source files.