### PR TITLE
Follow CMake Starter Version 2.2.0 Configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: Upload Project
         uses: actions/upload-artifact@v4.4.3
         with:
-          path: build/*.tar.gz
+          path: build/CDeps.tar.gz
           if-no-files-found: error
           overwrite: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,14 @@ project(
 option(CDEPS_ENABLE_TESTS "Enable test targets.")
 option(CDEPS_ENABLE_INSTALL "Enable install targets." ${PROJECT_IS_TOP_LEVEL})
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Prefer system packages over the find modules provided by this project.
 if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
   set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 endif()
 
-include(cmake/CDeps.cmake)
+include(CDeps)
 
 if(CDEPS_ENABLE_TESTS)
   enable_testing()
@@ -38,7 +38,8 @@ endif()
 
 if(CDEPS_ENABLE_INSTALL)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake/CDepsConfig.cmake
-    "include(\${CMAKE_CURRENT_LIST_DIR}/CDeps.cmake)\n")
+    "list(PREPEND CMAKE_MODULE_PATH \${CMAKE_CURRENT_LIST_DIR})\n"
+    "include(CDeps)\n")
 
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(cmake/CDepsConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include(CDeps)
 if(CDEPS_ENABLE_TESTS)
   enable_testing()
 
-  find_package(Assertion 1.0.0 REQUIRED)
+  find_package(Assertion 2.0.0 REQUIRED)
   list(APPEND CMAKE_SCRIPT_TEST_DEFINITIONS CMAKE_MODULE_PATH)
 
   add_cmake_script_test(test/test_build_generator.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,6 @@ if(CDEPS_ENABLE_INSTALL)
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/CDepsConfigVersion.cmake
     DESTINATION lib/cmake/CDeps)
 
-  set(CPACK_SYSTEM_NAME any)
+  set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}")
   include(CPack)
 endif()

--- a/cmake/FindAssertion.cmake
+++ b/cmake/FindAssertion.cmake
@@ -1,11 +1,9 @@
-file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v2.0.0/Assertion.cmake
-    ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
-  EXPECTED_MD5 5ebe475aee6fc5660633152f815ce9f6)
-include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
+set(DOWNLOAD_URL https://github.com/threeal/assertion-cmake/releases/download)
+file(DOWNLOAD ${DOWNLOAD_URL}/v${Assertion_FIND_VERSION}/Assertion.tar.gz
+  ${CMAKE_BINARY_DIR}/_deps/Assertion.tar.gz)
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-  Assertion REQUIRED_VARS ASSERTION_VERSION VERSION_VAR ASSERTION_VERSION)
+file(ARCHIVE_EXTRACT INPUT ${CMAKE_BINARY_DIR}/_deps/Assertion.tar.gz
+  DESTINATION ${CMAKE_BINARY_DIR}/_deps)
 
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR}/cmake)
+include(CMakeFindDependencyMacro)
+find_dependency(Assertion CONFIG PATHS ${CMAKE_BINARY_DIR}/_deps)


### PR DESCRIPTION
This pull request resolves #193 by implementing the CMake Starter version 2.2.0 configuration as follows:
- Prepends the `CMAKE_MODULE_PATH` variable with the path to the main module directory.
- Modifies the `FindAssertion.cmake` module to download the `Assertion.tar.gz` file to satisfy the Assertion package find.
- Simplifies the package file name.