### PR TITLE
Bump C++ Starter in CI to Version 2.0.0

### DIFF
--- a/test/test_integration.cmake
+++ b/test/test_integration.cmake
@@ -26,7 +26,7 @@ section("it should regenerate the source code of the test project")
     "\n"
     "include(${CDEPS_LIST_FILE})\n"
     "\n"
-    "cdeps_download_package(CppStarter github.com/threeal/cpp-starter v1.0.0)\n"
+    "cdeps_download_package(CppStarter github.com/threeal/cpp-starter v2.0.0)\n"
     "cdeps_build_package(CppStarter GENERATOR \"\${CMAKE_GENERATOR}\")\n"
     "cdeps_install_package(CppStarter)\n"
     "\n"


### PR DESCRIPTION
This pull request bumps the C++ Starter that being used in `test_integration.cmake` to [version 2.0.0](https://github.com/threeal/cpp-starter/releases/tag/v2.0.0).